### PR TITLE
#7: update SharpXMPP dependency

### DIFF
--- a/emulsion.fsproj
+++ b/emulsion.fsproj
@@ -16,6 +16,6 @@
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="SharpXMPP.Shared" Version="0.0.1-pre01" />
+    <PackageReference Include="SharpXMPP.Shared" Version="0.0.1-pre02" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I've just published the new version of SharpXMPP to NuGet, and used it here.

That new version includes fix for the issue https://github.com/vitalyster/SharpXMPP/issues/15. Emulsion bot wasn't able to connect to our own XMPP server due to that bug.

Now it can connect to our server; I've verified that fact.