### PR TITLE
Update to .NET Core 2, enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+os: linux
+dist: trusty
+env:
+    global:
+        - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+        - DOTNET_CLI_TELEMETRY_OPTOUT=1
+dotnet: 2.0.0
+script:
+    - dotnet build

--- a/Readme.md
+++ b/Readme.md
@@ -8,8 +8,7 @@ Build
 
 Install [.NET Core SDK][dotnet-core-sdk] for your platform, then run:
 
-```
-$ dotnet restore
+```console
 $ dotnet build
 ```
 
@@ -21,9 +20,9 @@ Copy `emulsion.example.json` to `emulsion.json` and set the settings.
 Run
 ---
 
-Requires [.NET Core Runtime][dotnet-core-runtime] version 1.1+.
+Requires [.NET Core Runtime][dotnet-core-runtime] version 2.0+.
 
-```
+```console
 $ dotnet run [optional-path-to-json-config-file]
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-emulsion
+emulsion [![Appveyor Build][badge-appveyor]][build-appveyor] [![Travis Build][badge-travis]][build-travis] [![Status Umbra][status-umbra]][andivionian-status-classifier]
 ========
 
 emulsion is a bridge between [Telegram][telegram] and [XMPP][xmpp].
@@ -26,7 +26,14 @@ Requires [.NET Core Runtime][dotnet-core-runtime] version 2.0+.
 $ dotnet run [optional-path-to-json-config-file]
 ```
 
+[andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-umbra-
+[build-appveyor]: https://ci.appveyor.com/project/ForNeVeR/emulsion/branch/master
+[build-travis]: https://travis-ci.org/codingteam/emulsion
 [dotnet-core-runtime]: https://www.microsoft.com/net/download/core#/runtime
 [dotnet-core-sdk]: https://www.microsoft.com/net/download/core
 [telegram]: https://telegram.org/
 [xmpp]: https://xmpp.org/
+
+[badge-appveyor]: https://ci.appveyor.com/api/projects/status/dgrpxj0dx221ii89/branch/master?svg=true
+[badge-travis]: https://travis-ci.org/codingteam/emulsion.svg?branch=master
+[status-umbra]: https://img.shields.io/badge/status-umbra-red.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+os: Visual Studio 2017
+skip_branch_with_pr: true
+environment:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+build_script:
+    - dotnet build

--- a/emulsion.fsproj
+++ b/emulsion.fsproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EmulsionSettings.fs" />
@@ -12,8 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Funogram" Version="1.1.3-alpha" />
-    <PackageReference Include="FSharp.Core" Version="4.2.1" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="SharpXMPP.Shared" Version="0.0.1-pre02" />


### PR DESCRIPTION
Closes #5.

Also chose to update to .NET Core 2.0, because it's easier to run tests and redistribute.