### PR TITLE
Pass Telegram user names to XMPP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 obj/
 
 emulsion.json
+
+*.user

--- a/Emulsion.Tests/Actors/Core.fs
+++ b/Emulsion.Tests/Actors/Core.fs
@@ -38,11 +38,11 @@ type CoreTests() as this =
     [<Fact>]
     member this.``Core sends XMPP message to Telegram actor``() =
         let core = spawnCore()
-        core.Tell(XmppMessage("xxx", "x"))
-        telegramActor.ExpectMsg(OutgoingMessage("xxx", "x"))
+        core.Tell(XmppMessage { author = "xxx"; text = "x" })
+        telegramActor.ExpectMsg(OutgoingMessage { author = "xxx"; text = "x" })
 
     [<Fact>]
     member this.``Core sends Telegram message to XMPP actor``() =
         let core = spawnCore()
-        core.Tell(TelegramMessage "x")
-        xmppActor.ExpectMsg(OutgoingMessage("Telegram user", "x"))
+        core.Tell(TelegramMessage { author = "Telegram user"; text = "x" })
+        xmppActor.ExpectMsg(OutgoingMessage { author = "Telegram user"; text = "x" })

--- a/Emulsion.Tests/Actors/Telegram.fs
+++ b/Emulsion.Tests/Actors/Telegram.fs
@@ -17,7 +17,7 @@ type TelegramTest() =
             { run = fun _ _ -> ()
               send = fun _ msg -> sentMessage := Some msg }
         let actor = Telegram.spawn Settings.testConfiguration.telegram telegram this.Sys this.TestActor "telegram"
-        let msg = OutgoingMessage("x", "message")
+        let msg = OutgoingMessage { author = "x"; text = "message" }
         actor.Tell(msg, this.TestActor)
         this.ExpectNoMsg()
         Assert.Equal(Some msg, !sentMessage)

--- a/Emulsion.Tests/Actors/Xmpp.fs
+++ b/Emulsion.Tests/Actors/Xmpp.fs
@@ -20,6 +20,6 @@ type XmppTest() =
               run = fun _ -> ()
               send = fun _ msg -> sentMessage := msg }
         let actor = Xmpp.spawn xmpp this.Sys this.TestActor "xmpp"
-        actor.Tell(OutgoingMessage("nickname", "message"), this.TestActor)
+        actor.Tell(OutgoingMessage { author = "@nickname"; text = "message" }, this.TestActor)
         this.ExpectNoMsg()
         Assert.Equal("<@nickname> message", !sentMessage)

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Actors/SyncTaskWatcher.fs" />
     <Compile Include="Actors/Telegram.fs" />
     <Compile Include="Actors/Xmpp.fs" />
+    <Compile Include="Telegram.fs" />
     <Compile Include="Xmpp/SharpXmppHelper.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/Emulsion.Tests/Telegram.fs
+++ b/Emulsion.Tests/Telegram.fs
@@ -1,0 +1,54 @@
+module Emulsion.Tests.Telegram
+
+open Xunit
+open Emulsion
+open Funogram.Types
+
+let private createUser username firstName lastName = {
+    Id = 0L
+    FirstName = firstName
+    LastName = lastName
+    Username = username
+    LanguageCode = None
+}
+
+let private createMessage from text : Message =
+    { defaultMessage with
+        From = from
+        Text = text }
+
+[<Fact>]
+let convertMessageWithUnknownUser() =
+    Assert.Equal({ author = "[UNKNOWN USER]"; text = "" }, Telegram.convertMessage (createMessage None (Some "")))
+
+[<Fact>]
+let convertMessageWithKnownUsername() =
+    let user = createUser (Some "Username") "" None
+    Assert.Equal({ author = "@Username"; text = "" }, Telegram.convertMessage (createMessage (Some user) (Some "")))
+
+[<Fact>]
+let convertMessageWithFullName() =
+    let user = createUser None "FirstName" (Some "LastName")
+    Assert.Equal(
+        { author = "FirstName LastName"; text = "" },
+        Telegram.convertMessage (createMessage (Some user) (Some ""))
+    )
+
+[<Fact>]
+let convertMessageWithFirstNameOnly() =
+    let user = createUser None "FirstName" None
+    Assert.Equal({ author = "FirstName"; text = "" }, Telegram.convertMessage (createMessage (Some user) (Some "")))
+
+[<Fact>]
+let convertMessageWithText() =
+    Assert.Equal(
+        { author = "[UNKNOWN USER]"; text = "text" },
+        Telegram.convertMessage (createMessage None (Some "text"))
+    )
+
+[<Fact>]
+let convertMessageWithoutText() =
+    Assert.Equal(
+        { author = "[UNKNOWN USER]"; text = "[DATA UNRECOGNIZED]" },
+        Telegram.convertMessage (createMessage None None)
+    )

--- a/Emulsion.Tests/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion.Tests/Xmpp/SharpXmppHelper.fs
@@ -15,7 +15,7 @@ let ``parseMessage should extract message text and author``() =
     let element = XMPPMessage(Text = text)
     element.SetAttributeValue(XName.Get "from", "x@y/author")
     let message = SharpXmppHelper.parseMessage element
-    let expected = Some(XmppMessage("author", text))
+    let expected = Some(XmppMessage { author = "author"; text = text })
     Assert.Equal(expected, message)
 
 [<Fact>]

--- a/Emulsion/Actors/Core.fs
+++ b/Emulsion/Actors/Core.fs
@@ -21,8 +21,8 @@ type CoreActor(factories : ActorFactories) as this =
 
     member this.OnMessage(message : IncomingMessage) : unit =
         match message with
-        | TelegramMessage _ as msg -> xmpp.Tell(msg.ToOutgoing(), this.Self)
-        | XmppMessage _ as msg -> telegram.Tell(msg.ToOutgoing(), this.Self)
+        | TelegramMessage msg -> xmpp.Tell(OutgoingMessage msg, this.Self)
+        | XmppMessage msg -> telegram.Tell(OutgoingMessage msg, this.Self)
 
 let spawn (factories : ActorFactories) (system : IActorRefFactory) (name : string) : IActorRef =
     printfn "Spawning Core..."

--- a/Emulsion/Actors/Xmpp.fs
+++ b/Emulsion/Actors/Xmpp.fs
@@ -18,8 +18,8 @@ type XmppActor(core : IActorRef, xmpp : XmppModule) as this =
         printfn "Starting XMPP connection..."
         xmpp.run robot
 
-    member private __.OnMessage(OutgoingMessage(author, text)) : unit =
-        let msg = sprintf "<@%s> %s" author text
+    member private __.OnMessage(OutgoingMessage { author = author; text = text }) : unit =
+        let msg = sprintf "<%s> %s" author text
         xmpp.send robot msg
 
 let spawn (xmpp : XmppModule)

--- a/Emulsion/AssemblyInfo.fs
+++ b/Emulsion/AssemblyInfo.fs
@@ -1,0 +1,6 @@
+namespace Emulsion
+
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleTo("Emulsion.Tests")>]
+()

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="EmulsionSettings.fs" />
     <Compile Include="Message.fs" />
     <Compile Include="Telegram.fs" />

--- a/Emulsion/Message.fs
+++ b/Emulsion/Message.fs
@@ -1,13 +1,14 @@
 namespace Emulsion
 
+[<Struct>]
+type Message = {
+    author : string
+    text : string
+}
+
 type OutgoingMessage =
-| OutgoingMessage of author : string * text : string
+| OutgoingMessage of Message
 
 type IncomingMessage =
-| XmppMessage of author : string * text : string
-| TelegramMessage of string
-with
-    member this.ToOutgoing() =
-        match this with
-        | XmppMessage(author, text) -> OutgoingMessage(author, text)
-        | TelegramMessage text -> OutgoingMessage("Telegram user", text)
+| XmppMessage of Message
+| TelegramMessage of Message

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Emulsion.Program
 
-open System
 open System.IO
 
 open Akka.Actor

--- a/Emulsion/Telegram.fs
+++ b/Emulsion/Telegram.fs
@@ -14,81 +14,13 @@ let private processResultWithValue (result: Result<'a, ApiResponseError>) =
         printfn "Error: %s" e.Description
         None
 
-let private defaultText = """⭐️Available test commands:
-/send_message1 - Markdown test
-/send_message2 - HTML test
-/send_message3 - Disable web page preview and notifications
-/send_message4 - Test reply message
-/send_message5 - Test ReplyKeyboardMarkup
-/send_message6 - Test RemoveKeyboardMarkup
-/forward_message - Test forward message
-/show_my_photos_sizes - Test getUserProfilePhotos method
-/get_chat_info - Returns id and type of current chat"""
-
 let private processResult (result: Result<'a, ApiResponseError>) =
     processResultWithValue result |> ignore
 
 let private updateArrived onMessage (ctx : UpdateContext) =
-    let bot data = api ctx.Config.Token data |> Async.RunSynchronously |> processResult
-    let botResult data = api ctx.Config.Token data |> Async.RunSynchronously
-
-    let getChatInfo msg =
-        let result = botResult (getChat msg.Chat.Id)
-        match result with
-        | Ok x ->
-            botResult (sendMessage msg.Chat.Id (sprintf "Id: %i, Type: %s" x.Id x.Type))
-            |> processResultWithValue
-            |> ignore
-        | Error e -> printf "Error: %s" e.Description
-
-    let fromId() = ctx.Update.Message.Value.From.Value.Id
-
-    let sayWithArgs text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup =
-        bot (sendMessageBase (ChatId.Int (fromId())) text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup)
-
-    let sendMessageFormatted text parseMode = bot (sendMessageBase (ChatId.Int(fromId())) text (Some parseMode) None None None None)
-
-    let result =
-        processCommands ctx [
-            cmd "/send_message1" (fun _ -> sendMessageFormatted "Test *Markdown*" ParseMode.Markdown)
-            cmd "/send_message2" (fun _ -> sendMessageFormatted "Test <b>HTML</b>" ParseMode.HTML)
-            cmd "/send_message3" (fun _ -> sayWithArgs "@Dolfik! See http://fsharplang.ru - Russian F# Community" None (Some true) (Some true) None None)
-            cmd "/send_message4" (fun _ -> sayWithArgs "That's message with reply!" None None None (Some ctx.Update.Message.Value.MessageId) None)
-            cmd "/send_message5" (fun _ ->
-            (
-                let keyboard = (Seq.init 2 (fun x -> Seq.init 2 (fun y -> { Text = y.ToString() + x.ToString(); RequestContact = None; RequestLocation = None })))
-                let markup = Markup.ReplyKeyboardMarkup {
-                    Keyboard = keyboard
-                    ResizeKeyboard = None
-                    OneTimeKeyboard = None
-                    Selective = None
-                }
-                bot (sendMessageMarkup (fromId()) "That's keyboard!" markup)
-            ))
-            cmd "/send_message6" (fun _ ->
-            (
-                let markup = Markup.ReplyKeyboardRemove { RemoveKeyboard = true; Selective = None; }
-                bot (sendMessageMarkup (fromId()) "Keyboard was removed!" markup)
-            ))
-            cmd "/forward_message" (fun _ -> bot (forwardMessage (fromId()) (fromId()) ctx.Update.Message.Value.MessageId))
-            cmd "/show_my_photos_sizes" (fun _ ->
-            (
-                let x = botResult (getUserProfilePhotosAll (fromId())) |> processResultWithValue
-                if x.IsNone then ()
-                else
-                    let text = sprintf "Photos: %s" (x.Value.Photos
-                                |> Seq.map (fun f -> f |> Seq.last)
-                                |> Seq.map (fun f -> sprintf "%ix%i" f.Width f.Height)
-                                |> String.concat ",")
-
-                    bot (sendMessage (fromId()) text)
-            ))
-            cmd "/get_chat_info" (fun _ -> getChatInfo ctx.Update.Message.Value)
-            fun (msg, user) -> onMessage msg.Text.Value; true
-        ]
-
-    if result then ()
-    else bot (sendMessage (fromId()) defaultText)
+    processCommands ctx [
+        fun (msg, _) -> onMessage msg.Text.Value; true
+    ] |> ignore
 
 let send (settings : TelegramSettings) (OutgoingMessage(author, text)) : unit =
     let message = sprintf "<%s> %s" author text

--- a/Emulsion/Telegram.fs
+++ b/Emulsion/Telegram.fs
@@ -17,23 +17,37 @@ let private processResultWithValue (result: Result<'a, ApiResponseError>) =
 let private processResult (result: Result<'a, ApiResponseError>) =
     processResultWithValue result |> ignore
 
+let internal convertMessage (message : Message) =
+    let authorName =
+        match message.From with
+        | None -> "[UNKNOWN USER]"
+        | Some user ->
+            match user.Username with
+            | Some username -> sprintf "@%s" username
+            | None ->
+                match user.LastName with
+                | Some lastName -> sprintf "%s %s" user.FirstName lastName
+                | None -> user.FirstName
+    let text = Option.defaultValue "[DATA UNRECOGNIZED]" message.Text
+    { author = authorName; text = text }
+
 let private updateArrived onMessage (ctx : UpdateContext) =
     processCommands ctx [
-        fun (msg, _) -> onMessage msg.Text.Value; true
+        fun (msg, _) -> onMessage (convertMessage msg); true
     ] |> ignore
 
-let send (settings : TelegramSettings) (OutgoingMessage(author, text)) : unit =
+let send (settings : TelegramSettings) (OutgoingMessage { author = author; text = text }) : unit =
     let message = sprintf "<%s> %s" author text
     api settings.token (sendMessage (int64 settings.groupId) message)
     |> Async.RunSynchronously
     |> processResult
 
-let run (settings : TelegramSettings) (onMessage : string -> unit) : unit =
+let run (settings : TelegramSettings) (onMessage : Emulsion.Message -> unit) : unit =
     let config = { defaultConfig with Token = settings.token }
     Bot.startBot config (updateArrived onMessage) None
 
 type TelegramModule =
-    { run : TelegramSettings -> (string -> unit) -> unit
+    { run : TelegramSettings -> (Emulsion.Message -> unit) -> unit
       send : TelegramSettings -> OutgoingMessage -> unit }
 
 let telegramModule : TelegramModule =

--- a/Emulsion/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion/Xmpp/SharpXmppHelper.fs
@@ -40,4 +40,4 @@ let private getResource jidText = JID(jidText).Resource
 let parseMessage (message : XMPPMessage) : IncomingMessage option =
     getAttributeValue message "from"
     |> Option.map getResource
-    |> Option.map (fun nickname -> XmppMessage(nickname, message.Text))
+    |> Option.map (fun nickname -> XmppMessage { author = nickname; text = message.Text })


### PR DESCRIPTION
Closes #20.

Also introduces a small cleanup in our Telegram client code (removes the unnecessary test commands).