### PR TITLE
Fix the XMPP reconnection issues

### DIFF
--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -26,6 +26,6 @@
     <PackageReference Include="Funogram" Version="1.1.3-alpha" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="SharpXMPP" Version="0.0.1" />
+    <PackageReference Include="SharpXMPP" Version="0.0.2" />
   </ItemGroup>
 </Project>

--- a/Emulsion/MessageSystem.fs
+++ b/Emulsion/MessageSystem.fs
@@ -46,6 +46,8 @@ type MessageSystemBase(ctx: RestartContext, cancellationToken: CancellationToken
 
     /// Starts the IM connection, manages reconnects. On cancellation could either throw OperationCanceledException or
     /// return a unit.
+    ///
+    /// This method will never be called multiple times in parallel on a single instance.
     abstract member RunUntilError : IncomingMessageReceiver -> Async<unit>
 
     /// Sends a message through the message system. Free-threaded. Could throw exceptions; if throws an exception, then

--- a/Emulsion/Xmpp/Client.fs
+++ b/Emulsion/Xmpp/Client.fs
@@ -8,11 +8,21 @@ open Emulsion.Settings
 
 type Client(ctx: RestartContext, cancellationToken: CancellationToken, settings: XmppSettings) =
     inherit MessageSystemBase(ctx, cancellationToken)
-    let client = XmppClient.create settings
 
-    override __.RunUntilError receiver =
-        XmppClient.run settings client receiver
+    let client = ref None
+
+    override __.RunUntilError receiver = async {
+        use newClient = XmppClient.create settings receiver
+        try
+            Volatile.Write(client, Some newClient)
+            do! XmppClient.run newClient
+        finally
+            Volatile.Write(client, None)
+    }
 
     override __.Send (OutgoingMessage message) = async {
-         return XmppClient.send settings client message
+         match Volatile.Read(client) with
+         | None -> failwith "Client is offline"
+         | Some client ->
+            return XmppClient.send settings client message
     }

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -42,6 +42,9 @@ let create (settings: XmppSettings): XmppClient =
     client
 
 exception ConnectionFailedError of string
+    with
+        override this.ToString() =
+            sprintf "%A" this
 
 let run (settings: XmppSettings) (client: XmppClient) (onMessage: IncomingMessage -> unit): Async<unit> =
     printfn "Bot name: %s" client.Jid.FullJid

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -1,5 +1,6 @@
 module Emulsion.Xmpp.XmppClient
 
+open System
 open System.Threading.Tasks
 
 open SharpXMPP
@@ -42,17 +43,15 @@ let create (settings: XmppSettings) (onMessage: IncomingMessage -> unit): XmppCl
     client.add_Message(messageHandler settings onMessage)
     client
 
-exception ConnectionFailedError of string
-    with
-        override this.ToString() =
-            sprintf "%A" this
+type ConnectionFailedError(message: string, innerException: Exception) =
+    inherit Exception(message, innerException)
 
 let run (client: XmppClient): Async<unit> =
     printfn "Bot name: %s" client.Jid.FullJid
     let connectionFinished = TaskCompletionSource()
     let connectionFailedHandler =
         XmppConnection.ConnectionFailedHandler(
-            fun _ error -> connectionFinished.SetException(ConnectionFailedError error.Message)
+            fun _ error -> connectionFinished.SetException(ConnectionFailedError(error.Message, error.Exception))
         )
 
     async {

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -59,7 +59,7 @@ let run (settings: XmppSettings) (client: XmppClient) (onMessage: IncomingMessag
 
             client.add_Message handler
             client.add_ConnectionFailed connectionFailedHandler
-            client.Connect()
+            do! Async.AwaitTask(client.ConnectAsync token)
 
             do! Async.AwaitTask tcs.Task
         finally


### PR DESCRIPTION
This PR updates the SharpXMPP library to the newly released version 0.0.2.

In that release, I've fixed a couple of bugs, and the library API has been updating.

Impact:

- closes #41 (because of https://github.com/vitalyster/SharpXMPP/pull/22)
- closes #42 (because the API no more uses an `async void` horror from C#)
- somewhat improves the situation around #55 (throws proper exceptions when the client is know to be inactive instead of losing the messages)
- will improve the SharpXMPP error logging after we implement #16 (because of proper inner exception handling)