### PR TITLE
Serilog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.vscode/
+/logs/
 
 bin/
 obj/

--- a/Emulsion.Tests/Actors/Core.fs
+++ b/Emulsion.Tests/Actors/Core.fs
@@ -3,11 +3,13 @@
 open Akka.Actor
 open Akka.TestKit.Xunit2
 open Xunit
+open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.Actors
+open Serilog
 
-type CoreTests() as this =
+type CoreTests(testOutput: ITestOutputHelper) as this =
     inherit TestKit()
 
     let mutable actorsCreated = 0
@@ -22,7 +24,8 @@ type CoreTests() as this =
     let factories = { xmppFactory = testActorFactory
                       telegramFactory = testActorFactory }
 
-    let spawnCore() = Core.spawn factories this.Sys "core"
+    let logger = LoggerConfiguration().WriteTo.TestOutput(testOutput).CreateLogger()
+    let spawnCore() = Core.spawn logger factories this.Sys "core"
 
     [<Fact>]
     member this.``Core actor should spawn successfully``() =

--- a/Emulsion.Tests/Actors/Core.fs
+++ b/Emulsion.Tests/Actors/Core.fs
@@ -2,12 +2,13 @@
 
 open Akka.Actor
 open Akka.TestKit.Xunit2
+open Serilog
 open Xunit
 open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.Actors
-open Serilog
+open Emulsion.Tests
 
 type CoreTests(testOutput: ITestOutputHelper) as this =
     inherit TestKit()
@@ -24,7 +25,7 @@ type CoreTests(testOutput: ITestOutputHelper) as this =
     let factories = { xmppFactory = testActorFactory
                       telegramFactory = testActorFactory }
 
-    let logger = LoggerConfiguration().WriteTo.TestOutput(testOutput).CreateLogger()
+    let logger = Logging.xunitLogger testOutput
     let spawnCore() = Core.spawn logger factories this.Sys "core"
 
     [<Fact>]

--- a/Emulsion.Tests/Actors/Telegram.fs
+++ b/Emulsion.Tests/Actors/Telegram.fs
@@ -2,12 +2,14 @@ namespace Emulsion.Tests.Actors
 
 open Akka.TestKit.Xunit2
 open Xunit
+open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.Actors
 open Emulsion.MessageSystem
+open Emulsion.Tests
 
-type TelegramTest() =
+type TelegramTest(testOutput: ITestOutputHelper) =
     inherit TestKit()
 
     [<Fact>]
@@ -19,7 +21,7 @@ type TelegramTest() =
                 member __.PutMessage message =
                     sentMessage <- Some message
         }
-        let actor = Telegram.spawn telegram this.Sys "telegram"
+        let actor = Telegram.spawn (Logging.xunitLogger testOutput) telegram this.Sys "telegram"
         let msg = OutgoingMessage { author = "x"; text = "message" }
         actor.Tell(msg, this.TestActor)
         this.ExpectNoMsg()

--- a/Emulsion.Tests/Actors/Xmpp.fs
+++ b/Emulsion.Tests/Actors/Xmpp.fs
@@ -2,12 +2,14 @@ namespace Emulsion.Tests.Actors
 
 open Akka.TestKit.Xunit2
 open Xunit
+open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.Actors
 open Emulsion.MessageSystem
+open Emulsion.Tests
 
-type XmppTest() =
+type XmppTest(testOutput: ITestOutputHelper) =
     inherit TestKit()
 
     [<Fact>]
@@ -19,7 +21,7 @@ type XmppTest() =
                 member __.PutMessage message =
                     sentMessage <- Some message
         }
-        let actor = Xmpp.spawn xmpp this.Sys "xmpp"
+        let actor = Xmpp.spawn (Logging.xunitLogger testOutput) xmpp this.Sys "xmpp"
         let message = OutgoingMessage { author = "@nickname"; text = "message" }
         actor.Tell(message, this.TestActor)
         this.ExpectNoMsg()

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Akka.TestKit" Version="1.3.12" />
     <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="TaskBuilder.fs" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.8" />
     <PackageReference Include="TaskBuilder.fs" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -7,6 +7,7 @@
     <Compile Include="Settings.fs" />
     <Compile Include="MessageSenderTests.fs" />
     <Compile Include="MessageSystemTests.fs" />
+    <Compile Include="Logging.fs" />
     <Compile Include="Actors/Core.fs" />
     <Compile Include="Actors/Telegram.fs" />
     <Compile Include="Actors/Xmpp.fs" />

--- a/Emulsion.Tests/Logging.fs
+++ b/Emulsion.Tests/Logging.fs
@@ -1,0 +1,7 @@
+module Emulsion.Tests.Logging
+
+open Serilog
+open Xunit.Abstractions
+
+let xunitLogger (output: ITestOutputHelper): ILogger =
+    upcast LoggerConfiguration().WriteTo.TestOutput(output).CreateLogger()

--- a/Emulsion.Tests/MessageSenderTests.fs
+++ b/Emulsion.Tests/MessageSenderTests.fs
@@ -8,9 +8,9 @@ open Emulsion
 open Emulsion.MessageSender
 
 let private testContext = {
-    send = fun _ -> async { return () }
-    logError = ignore
-    cooldown = TimeSpan.Zero
+    Send = fun _ -> async { return () }
+    LogError = ignore
+    RestartCooldown = TimeSpan.Zero
 }
 
 [<Fact>]
@@ -19,7 +19,7 @@ let ``Message sender sends the messages sequentially``() =
     let messagesReceived = ResizeArray()
     let context = {
         testContext with
-            send = fun m -> async {
+            Send = fun m -> async {
                 lock messagesReceived (fun () ->
                     messagesReceived.Add m
                 )
@@ -46,8 +46,8 @@ let ``Message sender should be cancellable``() =
     let errors = ResizeArray()
     let context = {
         testContext with
-            send = fun _ -> failwith "Should not be called"
-            logError = fun e -> lock errors (fun () -> errors.Add e)
+            Send = fun _ -> failwith "Should not be called"
+            LogError = fun e -> lock errors (fun () -> errors.Add e)
     }
     let sender = MessageSender.startActivity(context, cts.Token)
     cts.Cancel()

--- a/Emulsion.Tests/MessageSystemTests.fs
+++ b/Emulsion.Tests/MessageSystemTests.fs
@@ -3,6 +3,7 @@ module Emulsion.Tests.MessageSystemTests
 open System
 open System.Threading
 
+open Serilog.Core
 open Xunit
 
 open Emulsion
@@ -17,8 +18,7 @@ let private performTest expectedStage runBody =
     }
     let context = {
         RestartCooldown = TimeSpan.Zero
-        LogError = ignore
-        LogMessage = ignore
+        Logger = Logger.None
     }
 
     try

--- a/Emulsion.Tests/MessageSystemTests.fs
+++ b/Emulsion.Tests/MessageSystemTests.fs
@@ -16,9 +16,9 @@ let private performTest expectedStage runBody =
         runBody cts stage
     }
     let context = {
-        cooldown = TimeSpan.Zero
-        logError = ignore
-        logMessage = ignore
+        RestartCooldown = TimeSpan.Zero
+        LogError = ignore
+        LogMessage = ignore
     }
 
     try

--- a/Emulsion.Tests/Settings.fs
+++ b/Emulsion.Tests/Settings.fs
@@ -24,14 +24,14 @@ let private testConfigText = @"{
 }"
 
 let testConfiguration =
-    { xmpp =
-        { login = "login"
-          password = "password"
-          room = "room"
-          nickname = "nickname" }
-      telegram =
-        { token = "token"
-          groupId = "groupId" } }
+    { Xmpp =
+        { Login = "login"
+          Password = "password"
+          Room = "room"
+          Nickname = "nickname" }
+      Telegram =
+        { Token = "token"
+          GroupId = "groupId" } }
 
 let private mockConfiguration() =
     let path = Path.GetTempFileName()

--- a/Emulsion.Tests/Settings.fs
+++ b/Emulsion.Tests/Settings.fs
@@ -20,18 +20,27 @@ let private testConfigText = @"{
    ""telegram"": {
        ""token"": ""token"",
        ""groupId"": ""groupId""
+   },
+   ""log"": {
+       ""directory"": ""/tmp/""
    }
 }"
 
-let testConfiguration =
-    { Xmpp =
-        { Login = "login"
-          Password = "password"
-          Room = "room"
-          Nickname = "nickname" }
-      Telegram =
-        { Token = "token"
-          GroupId = "groupId" } }
+let testConfiguration = {
+    Xmpp = {
+        Login = "login"
+        Password = "password"
+        Room = "room"
+        Nickname = "nickname"
+    }
+    Telegram = {
+        Token = "token"
+        GroupId = "groupId"
+    }
+    Log = {
+        Directory = "/tmp/"
+    }
+}
 
 let private mockConfiguration() =
     let path = Path.GetTempFileName()

--- a/Emulsion.sln.DotSettings
+++ b/Emulsion.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=XMPP/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Emulsion/Actors/Core.fs
+++ b/Emulsion/Actors/Core.fs
@@ -17,7 +17,7 @@ type CoreActor(logger: ILogger, factories: ActorFactories) as this =
         factory ActorBase.Context name
 
     override this.PreStart() =
-        logger.Information "Core actor starting…"
+        logger.Information("Core actor starting ({Path})…", this.Self.Path)
         xmpp <- this.spawn factories.xmppFactory "xmpp"
         telegram <- this.spawn factories.telegramFactory "telegram"
 

--- a/Emulsion/Actors/Telegram.fs
+++ b/Emulsion/Actors/Telegram.fs
@@ -1,16 +1,17 @@
 ﻿module Emulsion.Actors.Telegram
 
 open Akka.Actor
+open Serilog
 
 open Emulsion
 open Emulsion.MessageSystem
 
-type TelegramActor(telegram: IMessageSystem) as this =
+type TelegramActor(logger: ILogger, telegram: IMessageSystem) as this =
     inherit ReceiveActor()
-    do printfn "Starting Telegram actor (%A)..." this.Self.Path
+    do logger.Information("Telegram actor starting ({Path})…", this.Self.Path)
     do this.Receive<OutgoingMessage>(MessageSystem.putMessage telegram)
 
-let spawn (telegram: IMessageSystem) (factory: IActorRefFactory) (name: string): IActorRef =
-    printfn "Spawning Telegram..."
-    let props = Props.Create<TelegramActor>(telegram)
+let spawn (logger: ILogger) (telegram: IMessageSystem) (factory: IActorRefFactory) (name: string): IActorRef =
+    logger.Information("Telegram actor spawning…")
+    let props = Props.Create<TelegramActor>(logger, telegram)
     factory.ActorOf(props, name)

--- a/Emulsion/Actors/Xmpp.fs
+++ b/Emulsion/Actors/Xmpp.fs
@@ -1,18 +1,20 @@
 module Emulsion.Actors.Xmpp
 
 open Akka.Actor
+open Serilog
 
 open Emulsion
 open Emulsion.MessageSystem
 
-type XmppActor(xmpp: IMessageSystem) as this =
+type XmppActor(logger: ILogger, xmpp: IMessageSystem) as this =
     inherit ReceiveActor()
-    do printfn "Starting XMPP actor (%A)..." this.Self.Path
+    do logger.Information("XMPP actor starting ({Path})…", this.Self.Path)
     do this.Receive<OutgoingMessage>(MessageSystem.putMessage xmpp)
 
-let spawn (xmpp: IMessageSystem)
+let spawn (logger: ILogger)
+          (xmpp: IMessageSystem)
           (factory: IActorRefFactory)
           (name: string): IActorRef =
-    printfn "Spawning XMPP..."
-    let props = Props.Create<XmppActor>(xmpp)
+    logger.Information("XMPP actor spawning…")
+    let props = Props.Create<XmppActor>(logger, xmpp)
     factory.ActorOf(props, name)

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Message.fs" />
     <Compile Include="MessageSender.fs" />
     <Compile Include="MessageSystem.fs" />
+    <Compile Include="Logging.fs" />
     <Compile Include="Telegram\Html.fs" />
     <Compile Include="Telegram\Funogram.fs" />
     <Compile Include="Telegram\Client.fs" />
@@ -26,6 +27,9 @@
     <PackageReference Include="Funogram" Version="1.1.3-alpha" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="SharpXMPP" Version="0.0.2" />
   </ItemGroup>
 </Project>

--- a/Emulsion/EmulsionSettings.fs
+++ b/Emulsion/EmulsionSettings.fs
@@ -1,31 +1,30 @@
 module Emulsion.Settings
 
 open Microsoft.Extensions.Configuration
-open System.Security
 
 type XmppSettings =
-    { login : string
-      password : string
-      room : string
-      nickname : string }
+    { Login : string
+      Password : string
+      Room : string
+      Nickname : string }
 
 type TelegramSettings =
-    { token : string
-      groupId : string }
+    { Token : string
+      GroupId : string }
 
 type EmulsionSettings =
-    { xmpp : XmppSettings
-      telegram : TelegramSettings }
+    { Xmpp : XmppSettings
+      Telegram : TelegramSettings }
 
 let read (config : IConfiguration) : EmulsionSettings =
     let readXmpp (section : IConfigurationSection) =
-        { login = section.["login"]
-          password = section.["password"]
-          room = section.["room"]
-          nickname = section.["nickname"] }
+        { Login = section.["login"]
+          Password = section.["password"]
+          Room = section.["room"]
+          Nickname = section.["nickname"] }
     let readTelegram (section : IConfigurationSection) =
-        { token = section.["token"]
-          groupId = section.["groupId"] }
+        { Token = section.["token"]
+          GroupId = section.["groupId"] }
 
-    { xmpp = readXmpp <| config.GetSection("xmpp")
-      telegram = readTelegram <| config.GetSection("telegram") }
+    { Xmpp = readXmpp <| config.GetSection("xmpp")
+      Telegram = readTelegram <| config.GetSection("telegram") }

--- a/Emulsion/EmulsionSettings.fs
+++ b/Emulsion/EmulsionSettings.fs
@@ -12,9 +12,15 @@ type TelegramSettings =
     { Token : string
       GroupId : string }
 
-type EmulsionSettings =
-    { Xmpp : XmppSettings
-      Telegram : TelegramSettings }
+type LogSettings = {
+    Directory: string
+}
+
+type EmulsionSettings = {
+    Xmpp : XmppSettings
+    Telegram : TelegramSettings
+    Log: LogSettings
+}
 
 let read (config : IConfiguration) : EmulsionSettings =
     let readXmpp (section : IConfigurationSection) =
@@ -25,6 +31,10 @@ let read (config : IConfiguration) : EmulsionSettings =
     let readTelegram (section : IConfigurationSection) =
         { Token = section.["token"]
           GroupId = section.["groupId"] }
+    let readLog(section: IConfigurationSection) = {
+        Directory = section.["directory"]
+    }
 
     { Xmpp = readXmpp <| config.GetSection("xmpp")
-      Telegram = readTelegram <| config.GetSection("telegram") }
+      Telegram = readTelegram <| config.GetSection("telegram")
+      Log = readLog <| config.GetSection "log" }

--- a/Emulsion/Logging.fs
+++ b/Emulsion/Logging.fs
@@ -1,0 +1,44 @@
+module Emulsion.Logging
+
+open System.IO
+
+open Serilog
+open Serilog.Core
+open Serilog.Filters
+
+open Emulsion.Settings
+open Serilog.Formatting.Json
+
+type EventCategory =
+    Telegram | Xmpp
+
+let private EventCategoryProperty = "EventCategory"
+
+let loggerWithCategory (category: EventCategory) (logger: ILogger) =
+    let enricher =
+        { new ILogEventEnricher with
+             member __.Enrich(logEvent, propertyFactory) =
+                 logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(EventCategoryProperty, category)) }
+    logger.ForContext enricher
+
+let createRootLogger (settings: LogSettings) =
+    let addFileLogger (category: EventCategory option) fileName (config: LoggerConfiguration) =
+        let filePath = Path.Combine(settings.Directory, fileName)
+        config.WriteTo.Logger(fun subConfig ->
+            let filtered =
+                match category with
+                | Some c -> subConfig.Filter.ByIncludingOnly(Matching.WithProperty(EventCategoryProperty, c))
+                | None -> subConfig.Filter.ByExcluding(Matching.WithProperty EventCategoryProperty)
+
+            filtered.WriteTo.RollingFile(JsonFormatter(), filePath)
+            |> ignore
+        )
+
+    let config =
+        LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Console()
+            |> addFileLogger (Some Telegram) "telegram.log"
+            |> addFileLogger (Some Xmpp) "xmpp.log"
+            |> addFileLogger None "system.log"
+    config.CreateLogger()

--- a/Emulsion/Logging.fs
+++ b/Emulsion/Logging.fs
@@ -9,17 +9,20 @@ open Serilog.Filters
 open Emulsion.Settings
 open Serilog.Formatting.Json
 
-type EventCategory =
+type private EventCategory =
     Telegram | Xmpp
 
 let private EventCategoryProperty = "EventCategory"
 
-let loggerWithCategory (category: EventCategory) (logger: ILogger) =
+let private loggerWithCategory (category: EventCategory) (logger: ILogger) =
     let enricher =
         { new ILogEventEnricher with
              member __.Enrich(logEvent, propertyFactory) =
                  logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(EventCategoryProperty, category)) }
     logger.ForContext enricher
+
+let telegramLogger: ILogger -> ILogger = loggerWithCategory Telegram
+let xmppLogger: ILogger -> ILogger = loggerWithCategory Xmpp
 
 let createRootLogger (settings: LogSettings) =
     let addFileLogger (category: EventCategory option) fileName (config: LoggerConfiguration) =

--- a/Emulsion/Logging.fs
+++ b/Emulsion/Logging.fs
@@ -27,7 +27,9 @@ let createRootLogger (settings: LogSettings) =
         config.WriteTo.Logger(fun subConfig ->
             let filtered =
                 match category with
-                | Some c -> subConfig.Filter.ByIncludingOnly(Matching.WithProperty(EventCategoryProperty, c))
+                | Some c ->
+                    let scalar = c.ToString() // required because log event properties are actually converted to strings
+                    subConfig.Filter.ByIncludingOnly(Matching.WithProperty(EventCategoryProperty, scalar))
                 | None -> subConfig.Filter.ByExcluding(Matching.WithProperty EventCategoryProperty)
 
             filtered.WriteTo.RollingFile(JsonFormatter(), filePath)

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -4,18 +4,18 @@ open System
 open System.Threading
 
 type MessageSenderContext = {
-    send: OutgoingMessage -> Async<unit>
-    logError: Exception -> unit
-    cooldown: TimeSpan
+    Send: OutgoingMessage -> Async<unit>
+    LogError: Exception -> unit
+    RestartCooldown: TimeSpan
 }
 
 let rec private sendRetryLoop ctx msg = async {
     try
-        do! ctx.send msg
+        do! ctx.Send msg
     with
     | ex ->
-        ctx.logError ex
-        do! Async.Sleep(int ctx.cooldown.TotalMilliseconds)
+        ctx.LogError ex
+        do! Async.Sleep(int ctx.RestartCooldown.TotalMilliseconds)
         return! sendRetryLoop ctx msg
 }
 

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -3,9 +3,11 @@ module Emulsion.MessageSender
 open System
 open System.Threading
 
+open Serilog
+
 type MessageSenderContext = {
     Send: OutgoingMessage -> Async<unit>
-    LogError: Exception -> unit
+    Logger: ILogger
     RestartCooldown: TimeSpan
 }
 
@@ -14,7 +16,9 @@ let rec private sendRetryLoop ctx msg = async {
         do! ctx.Send msg
     with
     | ex ->
-        ctx.LogError ex
+        ctx.Logger.Error(ex, "Error when trying to send message {Message}", msg)
+        ctx.Logger.Information("Waiting for {RestartCooldown} to resume processing output message queue",
+                               ctx.RestartCooldown)
         do! Async.Sleep(int ctx.RestartCooldown.TotalMilliseconds)
         return! sendRetryLoop ctx msg
 }

--- a/Emulsion/MessageSystem.fs
+++ b/Emulsion/MessageSystem.fs
@@ -1,8 +1,9 @@
 module Emulsion.MessageSystem
 
-open Serilog
 open System
 open System.Threading
+
+open Serilog
 
 type IncomingMessageReceiver = IncomingMessage -> unit
 

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -50,7 +50,7 @@ let private startApp config =
             let factories = { xmppFactory = Xmpp.spawn xmpp
                               telegramFactory = Telegram.spawn telegram }
             logger.Information "Core preparation…"
-            let core = Core.spawn factories system "core"
+            let core = Core.spawn logger factories system "core"
             logger.Information "Message systems preparation…"
             let! telegramSystem = startMessageSystem logger telegram core.Tell
             let! xmppSystem = startMessageSystem logger xmpp core.Tell

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -5,8 +5,8 @@ open System.IO
 
 open Akka.Actor
 open Microsoft.Extensions.Configuration
+open Serilog
 
-open System.Threading
 open Emulsion.Actors
 open Emulsion.MessageSystem
 open Emulsion.Settings
@@ -22,40 +22,47 @@ let private getConfiguration directory fileName =
 let private logError = printfn "ERROR: %A"
 let private logInfo = printfn "INFO : %s"
 
-let private startMessageSystem (system: IMessageSystem) receiver =
+let private startMessageSystem (logger: ILogger) (system: IMessageSystem) receiver =
     Async.StartChild <| async {
         do! Async.SwitchToNewThread()
         try
             system.Run receiver
         with
-        | ex -> logError ex
+        | ex -> logger.Error(ex, "Message system error {System}", system)
     }
 
 let private startApp config =
     async {
-        printfn "Prepare system..."
-        use system = ActorSystem.Create("emulsion")
-        printfn "Prepare factories..."
-        let restartContext = {
-            cooldown = TimeSpan.FromSeconds(30.0) // TODO[F]: Customize through the config.
-            logError = logError
-            logMessage = logInfo
-        }
-        let! cancellationToken = Async.CancellationToken
-        let xmpp = Xmpp.Client(restartContext, cancellationToken, config.Xmpp)
-        let telegram = Telegram.Client(restartContext, cancellationToken, config.Telegram)
-        let factories = { xmppFactory = Xmpp.spawn xmpp
-                          telegramFactory = Telegram.spawn telegram }
-        printfn "Prepare Core..."
-        let core = Core.spawn factories system "core"
-        printfn "Starting message systems..."
-        let! telegramSystem = startMessageSystem telegram core.Tell
-        let! xmppSystem = startMessageSystem xmpp core.Tell
-        printfn "Ready. Wait for termination..."
-        do! Async.AwaitTask system.WhenTerminated
-        printfn "Waiting for terminating of message systems..."
-        do! telegramSystem
-        do! xmppSystem
+        let logger = Logging.createRootLogger config.Log
+        try
+            logger.Information "Actor system preparation…"
+            use system = ActorSystem.Create("emulsion")
+            logger.Information "Clients preparation…"
+            let restartContext = {
+                cooldown = TimeSpan.FromSeconds(30.0) // TODO[F]: Customize through the config.
+                logError = logError
+                logMessage = logInfo
+            }
+            let! cancellationToken = Async.CancellationToken
+            let xmpp = Xmpp.Client(restartContext, cancellationToken, config.Xmpp)
+            let telegram = Telegram.Client(restartContext, cancellationToken, config.Telegram)
+            let factories = { xmppFactory = Xmpp.spawn xmpp
+                              telegramFactory = Telegram.spawn telegram }
+            logger.Information "Core preparation…"
+            let core = Core.spawn factories system "core"
+            logger.Information "Message systems preparation…"
+            let! telegramSystem = startMessageSystem logger telegram core.Tell
+            let! xmppSystem = startMessageSystem logger xmpp core.Tell
+            logger.Information "System ready"
+
+            logger.Information "Waiting for actor system termination…"
+            do! Async.AwaitTask system.WhenTerminated
+            logger.Information "Waiting for message systems termination…"
+            do! telegramSystem
+            do! xmppSystem
+        with
+        | error ->
+            logger.Fatal(error, "General application failure")
     }
 
 let private runApp app =

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -43,8 +43,8 @@ let private startApp config =
             use system = ActorSystem.Create("emulsion")
             logger.Information "Clients preparation…"
 
-            let xmppLogger = Logging.loggerWithCategory Logging.Xmpp logger
-            let telegramLogger = Logging.loggerWithCategory Logging.Telegram logger
+            let xmppLogger = Logging.xmppLogger logger
+            let telegramLogger = Logging.telegramLogger logger
 
             let! cancellationToken = Async.CancellationToken
             let xmpp = createClient xmppLogger Xmpp.Client cancellationToken config.Xmpp

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -38,14 +38,14 @@ let private startApp config =
             logger.Information "Actor system preparation…"
             use system = ActorSystem.Create("emulsion")
             logger.Information "Clients preparation…"
-            let restartContext = {
-                cooldown = TimeSpan.FromSeconds(30.0) // TODO[F]: Customize through the config.
-                logError = logError
-                logMessage = logInfo
+            let serviceContext = {
+                RestartCooldown = TimeSpan.FromSeconds(30.0) // TODO[F]: Customize through the config.
+                LogError = logError
+                LogMessage = logInfo
             }
             let! cancellationToken = Async.CancellationToken
-            let xmpp = Xmpp.Client(restartContext, cancellationToken, config.Xmpp)
-            let telegram = Telegram.Client(restartContext, cancellationToken, config.Telegram)
+            let xmpp = Xmpp.Client(serviceContext, cancellationToken, config.Xmpp)
+            let telegram = Telegram.Client(serviceContext, cancellationToken, config.Telegram)
             let factories = { xmppFactory = Xmpp.spawn xmpp
                               telegramFactory = Telegram.spawn telegram }
             logger.Information "Core preparation…"

--- a/Emulsion/Program.fs
+++ b/Emulsion/Program.fs
@@ -42,8 +42,8 @@ let private startApp config =
             logMessage = logInfo
         }
         let! cancellationToken = Async.CancellationToken
-        let xmpp = Xmpp.Client(restartContext, cancellationToken, config.xmpp)
-        let telegram = Telegram.Client(restartContext, cancellationToken, config.telegram)
+        let xmpp = Xmpp.Client(restartContext, cancellationToken, config.Xmpp)
+        let telegram = Telegram.Client(restartContext, cancellationToken, config.Telegram)
         let factories = { xmppFactory = Xmpp.spawn xmpp
                           telegramFactory = Telegram.spawn telegram }
         printfn "Prepare Core..."

--- a/Emulsion/Telegram/Client.fs
+++ b/Emulsion/Telegram/Client.fs
@@ -12,4 +12,4 @@ type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings:
         async { Funogram.run settings cancellationToken receiver }
 
     override __.Send message =
-        Funogram.send settings message
+        Funogram.send ctx.Logger settings message

--- a/Emulsion/Telegram/Client.fs
+++ b/Emulsion/Telegram/Client.fs
@@ -5,7 +5,7 @@ open System.Threading
 open Emulsion.MessageSystem
 open Emulsion.Settings
 
-type Client(ctx: RestartContext, cancellationToken: CancellationToken, settings: TelegramSettings) =
+type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings: TelegramSettings) =
     inherit MessageSystemBase(ctx, cancellationToken)
 
     override __.RunUntilError receiver =

--- a/Emulsion/Telegram/Funogram.fs
+++ b/Emulsion/Telegram/Funogram.fs
@@ -145,10 +145,10 @@ let send (settings : TelegramSettings) (OutgoingMessage content) : Async<unit> =
     let sendHtmlMessage groupId text =
         sendMessageBase groupId text (Some ParseMode.HTML) None None None None
 
-    let groupId = Int (int64 settings.groupId)
+    let groupId = Int (int64 settings.GroupId)
     let message = prepareHtmlMessage content
     async {
-        let! result = api settings.token (sendHtmlMessage groupId message)
+        let! result = api settings.Token (sendHtmlMessage groupId message)
         return processResult result
     }
 
@@ -156,5 +156,5 @@ let run (settings: TelegramSettings)
         (cancellationToken: CancellationToken)
         (onMessage: IncomingMessage -> unit) : unit =
     // TODO[F]: Update Funogram and don't ignore the cancellation token here.
-    let config = { defaultConfig with Token = settings.token }
+    let config = { defaultConfig with Token = settings.Token }
     Bot.startBot config (updateArrived onMessage) None

--- a/Emulsion/Xmpp/Client.fs
+++ b/Emulsion/Xmpp/Client.fs
@@ -6,7 +6,7 @@ open Emulsion
 open Emulsion.MessageSystem
 open Emulsion.Settings
 
-type Client(ctx: RestartContext, cancellationToken: CancellationToken, settings: XmppSettings) =
+type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings: XmppSettings) =
     inherit MessageSystemBase(ctx, cancellationToken)
 
     let client = ref None

--- a/Emulsion/Xmpp/Client.fs
+++ b/Emulsion/Xmpp/Client.fs
@@ -12,10 +12,10 @@ type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings:
     let client = ref None
 
     override __.RunUntilError receiver = async {
-        use newClient = XmppClient.create settings receiver
+        use newClient = XmppClient.create ctx.Logger settings receiver
         try
             Volatile.Write(client, Some newClient)
-            do! XmppClient.run newClient
+            do! XmppClient.run ctx.Logger newClient
         finally
             Volatile.Write(client, None)
     }

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -14,11 +14,11 @@ let private connectionFailedHandler = XmppConnection.ConnectionFailedHandler(fun
     ())
 
 let private signedInHandler (settings : XmppSettings) (client : XmppClient) = XmppConnection.SignedInHandler(fun s e ->
-    printfn "Connecting to %s" settings.room
-    SharpXmppHelper.joinRoom client settings.room settings.nickname)
+    printfn "Connecting to %s" settings.Room
+    SharpXmppHelper.joinRoom client settings.Room settings.Nickname)
 
 let private shouldSkipMessage settings message =
-    SharpXmppHelper.isOwnMessage (settings.nickname) message
+    SharpXmppHelper.isOwnMessage (settings.Nickname) message
         || SharpXmppHelper.isHistoricalMessage message
 
 let private messageHandler settings onMessage = XmppConnection.MessageHandler(fun _ element ->
@@ -35,7 +35,7 @@ let private presenceHandler = XmppConnection.PresenceHandler(fun s e ->
     printfn "[P]: %A" e)
 
 let create (settings: XmppSettings) (onMessage: IncomingMessage -> unit): XmppClient =
-    let client = new XmppClient(JID(settings.login), settings.password)
+    let client = new XmppClient(JID(settings.Login), settings.Password)
     client.add_ConnectionFailed(connectionFailedHandler)
     client.add_SignedIn(signedInHandler settings client)
     client.add_Element(elementHandler)
@@ -69,5 +69,5 @@ let run (client: XmppClient): Async<unit> =
 
 let send (settings: XmppSettings) (client: XmppClient) (message: Message): unit =
     let text = sprintf "<%s> %s" message.author message.text
-    SharpXmppHelper.message settings.room text
+    SharpXmppHelper.message settings.Room text
     |> client.Send

--- a/emulsion.example.json
+++ b/emulsion.example.json
@@ -8,5 +8,8 @@
     "telegram": {
         "token": "999999999:aaaaaaaaaaaaaaaaaaaaaaaaa_777777777",
         "groupId": "12312312312"
+    },
+    "log": {
+        "directory": "./logs/"
     }
 }


### PR DESCRIPTION
Closes #16.

We'll have not one, not two, but __three__ distinct, daily-rotated files to log our stuff to: one for system messages, one for XMPP and one for Telegram.

I've carefully eliminated every single one `printfn` call in our code (except one in the `main` function, that's good).