### PR TITLE
Convert links from Telegram

### DIFF
--- a/Emulsion/Telegram/Client.fs
+++ b/Emulsion/Telegram/Client.fs
@@ -9,7 +9,7 @@ type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings:
     inherit MessageSystemBase(ctx, cancellationToken)
 
     override __.RunUntilError receiver =
-        async { Funogram.run settings cancellationToken receiver }
+        async { Funogram.run ctx.Logger settings cancellationToken receiver }
 
     override __.Send message =
         Funogram.send ctx.Logger settings message

--- a/Emulsion/Telegram/Funogram.fs
+++ b/Emulsion/Telegram/Funogram.fs
@@ -1,6 +1,7 @@
 module Emulsion.Telegram.Funogram
 
 open System
+open System.Text
 open System.Threading
 
 open Funogram
@@ -9,7 +10,6 @@ open Funogram.Api
 open Funogram.Types
 open Serilog
 
-open System.Text
 open Emulsion
 open Emulsion.Settings
 


### PR DESCRIPTION
Closes #49.

There's a whole bunch of various corner cases and invalid markup types that may come from the Telegram server, and I've tried to handle them all properly.

We'll also log all the incoming Telegram messages.