### PR TITLE
MessageSender now supports two stages of MessageSystem work

### DIFF
--- a/Emulsion.Tests/Actors/Core.fs
+++ b/Emulsion.Tests/Actors/Core.fs
@@ -8,7 +8,7 @@ open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.Actors
-open Emulsion.Tests
+open Emulsion.Tests.TestUtils
 
 type CoreTests(testOutput: ITestOutputHelper) as this =
     inherit TestKit()

--- a/Emulsion.Tests/Actors/Telegram.fs
+++ b/Emulsion.Tests/Actors/Telegram.fs
@@ -7,7 +7,7 @@ open Xunit.Abstractions
 open Emulsion
 open Emulsion.Actors
 open Emulsion.MessageSystem
-open Emulsion.Tests
+open Emulsion.Tests.TestUtils
 
 type TelegramTest(testOutput: ITestOutputHelper) =
     inherit TestKit()

--- a/Emulsion.Tests/Actors/Xmpp.fs
+++ b/Emulsion.Tests/Actors/Xmpp.fs
@@ -7,7 +7,7 @@ open Xunit.Abstractions
 open Emulsion
 open Emulsion.Actors
 open Emulsion.MessageSystem
-open Emulsion.Tests
+open Emulsion.Tests.TestUtils
 
 type XmppTest(testOutput: ITestOutputHelper) =
     inherit TestKit()

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -4,17 +4,20 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TestUtils\LockedBuffer.fs" />
+    <Compile Include="TestUtils\Logging.fs" />
+    <Compile Include="TestUtils\Waiter.fs" />
     <Compile Include="Settings.fs" />
     <Compile Include="MessageSenderTests.fs" />
-    <Compile Include="MessageSystemTests.fs" />
-    <Compile Include="Logging.fs" />
     <Compile Include="Actors/Core.fs" />
     <Compile Include="Actors/Telegram.fs" />
     <Compile Include="Actors/Xmpp.fs" />
-    <Compile Include="Xmpp\XmppMessageFactory.fs" />
-    <Compile Include="Xmpp/SharpXmppHelper.fs" />
+    <Compile Include="MessageSystemTests\WrapRunTests.fs" />
+    <Compile Include="MessageSystemTests\MessageSystemBaseTests.fs" />
     <Compile Include="Telegram\Html.fs" />
     <Compile Include="Telegram\FunogramTests.fs" />
+    <Compile Include="Xmpp\XmppMessageFactory.fs" />
+    <Compile Include="Xmpp\SharpXmppHelper.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.TestKit" Version="1.3.12" />

--- a/Emulsion.Tests/Logging.fs
+++ b/Emulsion.Tests/Logging.fs
@@ -1,7 +1,0 @@
-module Emulsion.Tests.Logging
-
-open Serilog
-open Xunit.Abstractions
-
-let xunitLogger (output: ITestOutputHelper): ILogger =
-    upcast LoggerConfiguration().WriteTo.TestOutput(output).CreateLogger()

--- a/Emulsion.Tests/MessageSystemTests/MessageSystemBaseTests.fs
+++ b/Emulsion.Tests/MessageSystemTests/MessageSystemBaseTests.fs
@@ -1,0 +1,41 @@
+namespace Emulsion.Tests.MessageSystemTests
+
+open System
+open System.Threading
+
+open Xunit
+open Xunit.Abstractions
+
+open System.Threading.Tasks
+open Emulsion
+open Emulsion.MessageSystem
+open Emulsion.Tests.TestUtils
+open Emulsion.Tests.TestUtils.Waiter
+
+type MessageSystemBaseTests(testLogger: ITestOutputHelper) =
+    let logger = Logging.xunitLogger testLogger
+
+    [<Fact>]
+    member __.``Message system should send the messages after being started``() =
+        let context = { RestartCooldown = TimeSpan.Zero; Logger = logger }
+        let buffer = LockedBuffer()
+        use cts = new CancellationTokenSource()
+        let messageSystem =
+            { new MessageSystemBase(context, cts.Token) with
+                member __.RunUntilError _ =
+                    Async.Sleep Int32.MaxValue
+                member __.Send m = async {
+                    buffer.Add m
+                }
+            }
+        let msg = OutgoingMessage { author = "author"; text = "text" }
+        MessageSystem.putMessage messageSystem msg
+
+        let messageReceiver = ignore
+        let runningSystem = Task.Run(fun () -> (messageSystem :> IMessageSystem).Run messageReceiver)
+
+        waitForItemCount buffer 1 defaultTimeout |> Assert.True
+        Assert.Equal<OutgoingMessage>(Seq.singleton msg, buffer.All())
+
+        cts.Cancel()
+        Assert.Throws<OperationCanceledException>(fun () -> runningSystem.GetAwaiter().GetResult())

--- a/Emulsion.Tests/MessageSystemTests/WrapRunTests.fs
+++ b/Emulsion.Tests/MessageSystemTests/WrapRunTests.fs
@@ -1,4 +1,4 @@
-module Emulsion.Tests.MessageSystemTests
+module Emulsion.Tests.MessageSystemTests.WrapRunTests
 
 open System
 open System.Threading

--- a/Emulsion.Tests/Settings.fs
+++ b/Emulsion.Tests/Settings.fs
@@ -26,7 +26,7 @@ let private testConfigText = @"{
    }
 }"
 
-let testConfiguration = {
+let private testConfiguration = {
     Xmpp = {
         Login = "login"
         Password = "password"

--- a/Emulsion.Tests/TestUtils/LockedBuffer.fs
+++ b/Emulsion.Tests/TestUtils/LockedBuffer.fs
@@ -1,0 +1,14 @@
+namespace Emulsion.Tests.TestUtils
+
+type LockedBuffer<'T>() =
+    let messages = ResizeArray<'T>()
+    member __.Add(m: 'T) =
+        lock messages (fun () ->
+            messages.Add m
+        )
+    member __.Count(): int =
+        lock messages (fun () ->
+            messages.Count
+        )
+    member __.All(): 'T seq =
+        upcast ResizeArray messages

--- a/Emulsion.Tests/TestUtils/Logging.fs
+++ b/Emulsion.Tests/TestUtils/Logging.fs
@@ -1,0 +1,7 @@
+module Emulsion.Tests.TestUtils.Logging
+
+open Serilog
+open Xunit.Abstractions
+
+let xunitLogger (output: ITestOutputHelper): ILogger =
+    upcast LoggerConfiguration().MinimumLevel.Debug().WriteTo.TestOutput(output).CreateLogger()

--- a/Emulsion.Tests/TestUtils/Waiter.fs
+++ b/Emulsion.Tests/TestUtils/Waiter.fs
@@ -1,0 +1,10 @@
+module Emulsion.Tests.TestUtils.Waiter
+
+open System
+open System.Threading
+
+let defaultTimeout = TimeSpan.FromSeconds 30.0
+let shortTimeout = TimeSpan.FromSeconds 1.0
+
+let waitForItemCount (buffer: LockedBuffer<_>) count (timeout: TimeSpan) =
+    SpinWait.SpinUntil((fun () -> buffer.Count() = count), timeout)

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.12" />
+    <PackageReference Include="FSharpx.Collections" Version="2.0.0" />
     <PackageReference Include="Funogram" Version="1.1.3-alpha" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -3,6 +3,7 @@ module Emulsion.MessageSender
 open System
 open System.Threading
 
+open FSharpx.Collections
 open Serilog
 
 type MessageSenderContext = {
@@ -11,28 +12,63 @@ type MessageSenderContext = {
     RestartCooldown: TimeSpan
 }
 
-let rec private sendRetryLoop ctx msg = async {
+type private State = {
+    Messages: Queue<OutgoingMessage>
+    ReadyToAcceptMessages: bool
+} with static member initial = { Messages = Queue.empty; ReadyToAcceptMessages = false }
+
+let private trySendMessage ctx msg = async {
     try
         do! ctx.Send msg
+        return true
     with
     | ex ->
         ctx.Logger.Error(ex, "Error when trying to send message {Message}", msg)
-        ctx.Logger.Information("Waiting for {RestartCooldown} to resume processing output message queue",
-                               ctx.RestartCooldown)
-        do! Async.Sleep(int ctx.RestartCooldown.TotalMilliseconds)
-        return! sendRetryLoop ctx msg
+        return false
 }
 
-type Sender = MailboxProcessor<OutgoingMessage>
+let private processState ctx (state: State) = async {
+    ctx.Logger.Debug("Current queue state: {State}", state)
+    if not state.ReadyToAcceptMessages then
+        return state
+    else
+        match state.Messages with
+        | Queue.Nil -> return state
+        | Queue.Cons(message, rest) ->
+            let! success = trySendMessage ctx message
+            if not success then
+                ctx.Logger.Information("Waiting for {RestartCooldown} to resume processing output message queue",
+                                       ctx.RestartCooldown)
+                do! Async.Sleep(int ctx.RestartCooldown.TotalMilliseconds)
+            let newState =
+                if success
+                then { state with Messages = rest }
+                else state // leave the message in the queue
+            return newState
+}
+
+type Event =
+| QueueMessage of OutgoingMessage
+| SetReceiveStatus of bool
+
+type Sender = MailboxProcessor<Event>
 let private receiver ctx (inbox: Sender) =
-    let rec loop() = async {
+    let rec loop state = async {
         let! msg = inbox.Receive()
-        do! sendRetryLoop ctx msg
-        return! loop()
+        let newState =
+            match msg with
+            | QueueMessage m ->
+                let newMessages = Queue.conj m state.Messages
+                { state with Messages = newMessages }
+            | SetReceiveStatus status ->
+                { state with ReadyToAcceptMessages = status }
+        let! newState = processState ctx newState
+        return! loop newState
     }
-    loop()
+    loop State.initial
 
 let startActivity(ctx: MessageSenderContext, token: CancellationToken): Sender =
     MailboxProcessor.Start(receiver ctx, token)
 
-let send(activity: Sender): OutgoingMessage -> unit = activity.Post
+let setReadyToAcceptMessages(activity: Sender): bool -> unit = SetReceiveStatus >> activity.Post
+let send(activity: Sender): OutgoingMessage -> unit = QueueMessage >> activity.Post


### PR DESCRIPTION
Closes #66.

The `MessageSender` is now slightly aware of the `MessageSystem` state and won't try to send any messages while it isn't ready to accept them.

For now, the new concept is already used when the message system is restarting, but we will do more in scope of #18.

I've also rearranged some bits of our test code to reuse them in multiple tests.