### PR TITLE
Update the queue code in the MessageSender

### DIFF
--- a/Emulsion.Tests/MessageSenderTests.fs
+++ b/Emulsion.Tests/MessageSenderTests.fs
@@ -4,87 +4,129 @@ open System
 open System.Threading
 
 open Serilog
-open Serilog.Core
 open Serilog.Events
 open Serilog.Sinks.TestCorrelator
 open Xunit
+open Xunit.Abstractions
 
 open Emulsion
 open Emulsion.MessageSender
 open Emulsion.Tests.TestUtils
 open Emulsion.Tests.TestUtils.Waiter
 
-let private testContext = {
-    Send = fun _ -> async { return () }
-    Logger = Logger.None
-    RestartCooldown = TimeSpan.Zero
-}
-
-[<Fact>]
-let ``Message sender sends the messages sequentially``() =
-    use cts = new CancellationTokenSource()
-    let buffer = LockedBuffer()
-    let context = {
-        testContext with
-            Send = fun m -> async {
-                buffer.Add m
-            }
+type MessageSenderTests(testOutput: ITestOutputHelper) =
+    let testContext = {
+        Send = fun _ -> async { return () }
+        Logger = Logging.xunitLogger testOutput
+        RestartCooldown = TimeSpan.Zero
     }
-    let sender = MessageSender.startActivity(context, cts.Token)
-    MessageSender.setReadyToAcceptMessages sender true
 
-    let messagesSent = [| 1..100 |] |> Array.map (fun i ->
-        OutgoingMessage {
-            author = "author"
-            text = string i
-        }
-    )
-    messagesSent |> Array.iter(MessageSender.send sender)
-
-    waitForItemCount buffer messagesSent.Length defaultTimeout
-    |> Assert.True
-
-    Assert.Equal(messagesSent, buffer.All())
-
-[<Fact>]
-let ``Message sender should be cancellable``() =
-    use cts = new CancellationTokenSource()
-    using (TestCorrelator.CreateContext()) (fun _ ->
+    [<Fact>]
+    member __.``Message sender sends the messages sequentially``(): unit =
+        use cts = new CancellationTokenSource()
+        let buffer = LockedBuffer()
         let context = {
             testContext with
-                Send = fun _ -> failwith "Should not be called"
-                Logger = LoggerConfiguration().WriteTo.TestCorrelator().CreateLogger()
+                Send = fun m -> async {
+                    buffer.Add m
+                }
         }
         let sender = MessageSender.startActivity(context, cts.Token)
-        cts.Cancel()
+        MessageSender.setReadyToAcceptMessages sender true
 
-        let msg = OutgoingMessage { author = "author"; text = "xx" }
-        MessageSender.send sender msg
-
-        let getErrors() =
-            TestCorrelator.GetLogEventsFromCurrentContext()
-            |> Seq.filter (fun event -> event.Level = LogEventLevel.Error)
-
-        SpinWait.SpinUntil((fun () -> Seq.length(getErrors()) > 0), shortTimeout) |> ignore
-        Assert.Empty <| getErrors()
-    )
-
-let ``Message sender does nothing when the system is not ready to process the messages``() =
-    use cts = new CancellationTokenSource()
-    let buffer = LockedBuffer()
-    let context = {
-        testContext with
-            Send = fun m -> async {
-                buffer.Add m
+        let messagesSent = [| 1..100 |] |> Array.map (fun i ->
+            OutgoingMessage {
+                author = "author"
+                text = string i
             }
-    }
-    let sender = MessageSender.startActivity(context, cts.Token)
-    let msg = OutgoingMessage { author = "author"; text = "xx" }
+        )
+        messagesSent |> Array.iter(MessageSender.send sender)
 
-    MessageSender.setReadyToAcceptMessages sender true
-    MessageSender.send sender msg
-    waitForItemCount buffer 1 defaultTimeout |> Assert.True
+        waitForItemCount buffer messagesSent.Length defaultTimeout
+        |> Assert.True
 
-    MessageSender.setReadyToAcceptMessages sender false
-    MessageSender.send sender msg
-    waitForItemCount buffer 2 shortTimeout |> Assert.False
+        Assert.Equal(messagesSent, buffer.All())
+
+    [<Fact>]
+    member __.``Message sender should be cancellable``(): unit =
+        use cts = new CancellationTokenSource()
+        using (TestCorrelator.CreateContext()) (fun _ ->
+            let context = {
+                testContext with
+                    Send = fun _ -> failwith "Should not be called"
+                    Logger = LoggerConfiguration().WriteTo.TestCorrelator().CreateLogger()
+            }
+            let sender = MessageSender.startActivity(context, cts.Token)
+            cts.Cancel()
+
+            let msg = OutgoingMessage { author = "author"; text = "xx" }
+            MessageSender.send sender msg
+
+            let getErrors() =
+                TestCorrelator.GetLogEventsFromCurrentContext()
+                |> Seq.filter (fun event -> event.Level = LogEventLevel.Error)
+
+            SpinWait.SpinUntil((fun () -> Seq.length(getErrors()) > 0), shortTimeout) |> ignore
+            Assert.Empty <| getErrors()
+        )
+
+    [<Fact>]
+    member __.``Message sender does nothing when the system is not ready to process the messages``(): unit =
+        use cts = new CancellationTokenSource()
+        let buffer = LockedBuffer()
+        let context = {
+            testContext with
+                Send = fun m -> async {
+                    buffer.Add m
+                }
+        }
+        let sender = MessageSender.startActivity(context, cts.Token)
+        let msg = OutgoingMessage { author = "author"; text = "xx" }
+
+        MessageSender.setReadyToAcceptMessages sender true
+        MessageSender.send sender msg
+        waitForItemCount buffer 1 defaultTimeout |> Assert.True
+
+        MessageSender.setReadyToAcceptMessages sender false
+        MessageSender.send sender msg
+        waitForItemCount buffer 2 shortTimeout |> Assert.False
+
+    [<Fact>]
+    member __.``Message sender should empty the queue before blocking on further messages``(): unit =
+        use cts = new CancellationTokenSource()
+        let buffer = LockedBuffer()
+        let context = {
+            testContext with
+                Send = fun m -> async {
+                    buffer.Add m
+                }
+        }
+        let sender = MessageSender.startActivity(context, cts.Token)
+        MessageSender.setReadyToAcceptMessages sender false
+        MessageSender.send sender (OutgoingMessage { author = "author"; text = "1" })
+        MessageSender.send sender (OutgoingMessage { author = "author"; text = "2" })
+        MessageSender.setReadyToAcceptMessages sender true
+        waitForItemCount buffer 2 defaultTimeout |> Assert.True
+
+    [<Fact>]
+    member __.``Message sender should prioritize the SetReceiveStatus msg over flushing the queue``(): unit =
+        use cts = new CancellationTokenSource()
+        let buffer = LockedBuffer()
+        let mutable sender = Unchecked.defaultof<_>
+        let context = {
+            testContext with
+                Send = fun m -> async {
+                    // Let's send the setReadyToAcceptMessages immediately before sending any message
+                    MessageSender.setReadyToAcceptMessages sender false
+                    buffer.Add m
+                }
+        }
+        sender <- MessageSender.startActivity(context, cts.Token)
+
+        // This will send a message and block the second one:
+        MessageSender.setReadyToAcceptMessages sender true
+        MessageSender.send sender (OutgoingMessage { author = "author"; text = "1" })
+        waitForItemCount buffer 1 defaultTimeout |> Assert.True
+
+        MessageSender.send sender (OutgoingMessage { author = "author"; text = "2" })
+        waitForItemCount buffer 2 shortTimeout |> Assert.False

--- a/Emulsion.Tests/TestUtils/Waiter.fs
+++ b/Emulsion.Tests/TestUtils/Waiter.fs
@@ -6,8 +6,8 @@ open System.Threading
 let defaultTimeout = TimeSpan.FromSeconds 30.0
 let shortTimeout = TimeSpan.FromSeconds 1.0
 
-let waitForItemCountCond (buffer: LockedBuffer<_>) (condition: int -> bool) (timeout: TimeSpan) =
+let waitForItemCountCond (buffer: LockedBuffer<_>) (condition: int -> bool) (timeout: TimeSpan): bool =
     SpinWait.SpinUntil((fun () -> condition(buffer.Count())), timeout)
 
-let waitForItemCount (buffer: LockedBuffer<_>) count (timeout: TimeSpan) =
+let waitForItemCount (buffer: LockedBuffer<_>) count (timeout: TimeSpan): bool =
     waitForItemCountCond buffer (fun c -> c = count) timeout

--- a/Emulsion.Tests/TestUtils/Waiter.fs
+++ b/Emulsion.Tests/TestUtils/Waiter.fs
@@ -6,5 +6,8 @@ open System.Threading
 let defaultTimeout = TimeSpan.FromSeconds 30.0
 let shortTimeout = TimeSpan.FromSeconds 1.0
 
+let waitForItemCountCond (buffer: LockedBuffer<_>) (condition: int -> bool) (timeout: TimeSpan) =
+    SpinWait.SpinUntil((fun () -> condition(buffer.Count())), timeout)
+
 let waitForItemCount (buffer: LockedBuffer<_>) count (timeout: TimeSpan) =
-    SpinWait.SpinUntil((fun () -> buffer.Count() = count), timeout)
+    waitForItemCountCond buffer (fun c -> c = count) timeout

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -55,54 +55,38 @@ let private receiver ctx (inbox: Sender) =
     let rec loop (state: State) = async {
         ctx.Logger.Debug("Current queue state: {State}", state)
 
+        let processIncomingMessage msg = async {
+            let newState =
+                match msg with
+                | QueueMessage m ->
+                    let newMessages = Queue.conj m state.Messages
+                    { state with Messages = newMessages }
+                | SetReceiveStatus status ->
+                    { state with ReadyToAcceptMessages = status }
+            return! processState ctx newState
+        }
+
+        let blockAndProcessIncomingMessage() = async {
+            let! msg = inbox.Receive()
+            return! processIncomingMessage msg
+        }
+
         let! nextState =
             match state.ReadyToAcceptMessages, state.Messages with
             | false, _ -> // We aren't permitted to send any messages, we have nothing other to do than block on the
-                          // queue.
-                async {
-                    let! msg = inbox.Receive()
-                    let newState =
-                        match msg with
-                        | QueueMessage m ->
-                            let newMessages = Queue.conj m state.Messages
-                            { state with Messages = newMessages }
-                        | SetReceiveStatus status ->
-                            { state with ReadyToAcceptMessages = status }
-                    return! processState ctx newState
-                }
+                          // message queue.
+                blockAndProcessIncomingMessage()
             | true, Queue.Cons _ -> // We're permitted to send a message and the queue is not empty.
                 // Peek the queued message: maybe it's the `SetReceiveStatus false` which should have the priority over
-                // everything else.
+                // everything else. If there're no incoming messages, then just process the current state as usual.
                 async {
                     match! inbox.TryReceive 0 with
-                    | Some msg ->
-                        return! async {
-                            let newState =
-                                match msg with
-                                | QueueMessage m ->
-                                    let newMessages = Queue.conj m state.Messages
-                                    { state with Messages = newMessages }
-                                | SetReceiveStatus status ->
-                                    { state with ReadyToAcceptMessages = status }
-                            return! processState ctx newState
-                        }
-                    | None ->
-                        return! processState ctx state
+                    | Some msg -> return! processIncomingMessage msg
+                    | None -> return! processState ctx state
                 }
-
             | true, Queue.Nil -> // We're allowed to send a message, but the queue is empty. We have nothing to send,
-                                 // thus we have nothing to do other than to block.
-                async {
-                    let! msg = inbox.Receive()
-                    let newState =
-                        match msg with
-                        | QueueMessage m ->
-                            let newMessages = Queue.conj m state.Messages
-                            { state with Messages = newMessages }
-                        | SetReceiveStatus status ->
-                            { state with ReadyToAcceptMessages = status }
-                    return! processState ctx newState
-                }
+                                 // thus we have nothing to do other than to block on the message queue.
+                blockAndProcessIncomingMessage()
 
         return! loop nextState
     }

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -28,7 +28,6 @@ let private trySendMessage ctx msg = async {
 }
 
 let private processState ctx (state: State) = async {
-    ctx.Logger.Debug("Current queue state: {State}", state)
     if not state.ReadyToAcceptMessages then
         return state
     else
@@ -53,17 +52,59 @@ type Event =
 
 type Sender = MailboxProcessor<Event>
 let private receiver ctx (inbox: Sender) =
-    let rec loop state = async {
-        let! msg = inbox.Receive()
-        let newState =
-            match msg with
-            | QueueMessage m ->
-                let newMessages = Queue.conj m state.Messages
-                { state with Messages = newMessages }
-            | SetReceiveStatus status ->
-                { state with ReadyToAcceptMessages = status }
-        let! newState = processState ctx newState
-        return! loop newState
+    let rec loop (state: State) = async {
+        ctx.Logger.Debug("Current queue state: {State}", state)
+
+        let! nextState =
+            match state.ReadyToAcceptMessages, state.Messages with
+            | false, _ -> // We aren't permitted to send any messages, we have nothing other to do than block on the
+                          // queue.
+                async {
+                    let! msg = inbox.Receive()
+                    let newState =
+                        match msg with
+                        | QueueMessage m ->
+                            let newMessages = Queue.conj m state.Messages
+                            { state with Messages = newMessages }
+                        | SetReceiveStatus status ->
+                            { state with ReadyToAcceptMessages = status }
+                    return! processState ctx newState
+                }
+            | true, Queue.Cons _ -> // We're permitted to send a message and the queue is not empty.
+                // Peek the queued message: maybe it's the `SetReceiveStatus false` which should have the priority over
+                // everything else.
+                async {
+                    match! inbox.TryReceive 0 with
+                    | Some msg ->
+                        return! async {
+                            let newState =
+                                match msg with
+                                | QueueMessage m ->
+                                    let newMessages = Queue.conj m state.Messages
+                                    { state with Messages = newMessages }
+                                | SetReceiveStatus status ->
+                                    { state with ReadyToAcceptMessages = status }
+                            return! processState ctx newState
+                        }
+                    | None ->
+                        return! processState ctx state
+                }
+
+            | true, Queue.Nil -> // We're allowed to send a message, but the queue is empty. We have nothing to send,
+                                 // thus we have nothing to do other than to block.
+                async {
+                    let! msg = inbox.Receive()
+                    let newState =
+                        match msg with
+                        | QueueMessage m ->
+                            let newMessages = Queue.conj m state.Messages
+                            { state with Messages = newMessages }
+                        | SetReceiveStatus status ->
+                            { state with ReadyToAcceptMessages = status }
+                    return! processState ctx newState
+                }
+
+        return! loop nextState
     }
     loop State.initial
 


### PR DESCRIPTION
I had to reformat the test code because it is now a class (to inject the `ITestOutputHelper` instance). Only the two last tests were added in this PR.

Also, I've found that one of the test methods for the `MessageSender` was lacking the `Fact` attribute, so I've added it, too.

This PR fixes the queue logic: now it will only block on the incoming messages if it has nothing better to do (e.g. to deliver some queued messages). One of the new test verifies that behavior, and the other one verifies that the `SetReceiveStatus` of `false` will have a top priority and block delivering any messages even if they were queued beforehand.

Closes #82.