### PR TITLE
Add group id filtering for Telegram

### DIFF
--- a/Emulsion.Tests/SettingsTests.fs
+++ b/Emulsion.Tests/SettingsTests.fs
@@ -1,7 +1,7 @@
 module Emulsion.Tests.SettingsTests
 
-open System
 open System.IO
+open System.Threading.Tasks
 
 open FSharp.Control.Tasks
 open Microsoft.Extensions.Configuration
@@ -10,7 +10,8 @@ open Xunit
 open Emulsion
 open Emulsion.Settings
 
-let private testConfigText = @"{
+let private testConfigText groupIdLiteral =
+    sprintf @"{
    ""xmpp"": {
        ""login"": ""login"",
        ""password"": ""password"",
@@ -19,12 +20,12 @@ let private testConfigText = @"{
    },
    ""telegram"": {
        ""token"": ""token"",
-       ""groupId"": ""groupId""
+       ""groupId"": %s
    },
    ""log"": {
        ""directory"": ""/tmp/""
    }
-}"
+}" <| groupIdLiteral
 
 let private testConfiguration = {
     Xmpp = {
@@ -35,17 +36,17 @@ let private testConfiguration = {
     }
     Telegram = {
         Token = "token"
-        GroupId = "groupId"
+        GroupId = 200600L
     }
     Log = {
         Directory = "/tmp/"
     }
 }
 
-let private mockConfiguration() =
+let private mockConfiguration groupIdLiteral =
     let path = Path.GetTempFileName()
     task {
-        do! File.WriteAllTextAsync(path, testConfigText)
+        do! File.WriteAllTextAsync(path, testConfigText groupIdLiteral)
         return ConfigurationBuilder().AddJsonFile(path).Build()
     }
 
@@ -53,6 +54,13 @@ let private mockConfiguration() =
 [<Fact>]
 let ``Settings read properly`` () =
     task {
-        let! configuration = mockConfiguration()
+        let! configuration = mockConfiguration "200600"
+        Assert.Equal(testConfiguration, Settings.read configuration)
+    }
+
+[<Fact>]
+let ``Settings read the group id as string``(): Task<unit> =
+    task {
+        let! configuration = mockConfiguration "\"200600\""
         Assert.Equal(testConfiguration, Settings.read configuration)
     }

--- a/Emulsion.Tests/Telegram/FunogramTests.fs
+++ b/Emulsion.Tests/Telegram/FunogramTests.fs
@@ -79,8 +79,7 @@ let private replyingUser = createUser (Some "replyingUser") "" None
 let private forwardingUser = createUser (Some "forwardingUser") "" None
 
 module ReadMessageTests =
-    let readMessageOpt = MessageConverter.read { SelfUserId = selfUserId; GroupId = groupId }
-    let readMessage = readMessageOpt >> Option.get
+    let readMessage = MessageConverter.read selfUserId
 
     [<Fact>]
     let readMessageWithUnknownUser() =
@@ -280,11 +279,14 @@ module ReadMessageTests =
             readMessage reply
         )
 
+module ProcessMessageTests =
+    let private processMessage = Funogram.processMessage {| SelfUserId = selfUserId; GroupId = groupId |}
+
     [<Fact>]
     let messageFromOtherChatShouldBeIgnored(): unit =
         let message = { createMessage (Some originalUser) (Some "test") with
                           Chat = defaultChat }
-        Assert.Equal(None, readMessageOpt message)
+        Assert.Equal(None, processMessage message)
 
 module FlattenMessageTests =
     let private flattenMessage = Funogram.MessageConverter.flatten Funogram.MessageConverter.DefaultQuoteSettings

--- a/Emulsion/EmulsionSettings.fs
+++ b/Emulsion/EmulsionSettings.fs
@@ -8,9 +8,10 @@ type XmppSettings =
       Room : string
       Nickname : string }
 
-type TelegramSettings =
-    { Token : string
-      GroupId : string }
+type TelegramSettings = {
+    Token: string
+    GroupId: int64
+}
 
 type LogSettings = {
     Directory: string
@@ -28,9 +29,10 @@ let read (config : IConfiguration) : EmulsionSettings =
           Password = section.["password"]
           Room = section.["room"]
           Nickname = section.["nickname"] }
-    let readTelegram (section : IConfigurationSection) =
-        { Token = section.["token"]
-          GroupId = section.["groupId"] }
+    let readTelegram (section : IConfigurationSection) = {
+        Token = section.["token"]
+        GroupId = int64 section.["groupId"]
+    }
     let readLog(section: IConfigurationSection) = {
         Directory = section.["directory"]
     }

--- a/emulsion.example.json
+++ b/emulsion.example.json
@@ -7,7 +7,7 @@
     },
     "telegram": {
         "token": "999999999:aaaaaaaaaaaaaaaaaaaaaaaaa_777777777",
-        "groupId": "12312312312"
+        "groupId": 12312312312
     },
     "log": {
         "directory": "./logs/"


### PR DESCRIPTION
Closes #85.

Aside from adding the filter, I've also defined a proper group id type in the configuration, since we want to compare it with the actual group id received from the server.