### PR TITLE
Update SharpXMPP to 0.0.3

### DIFF
--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -40,6 +40,6 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="SharpXMPP" Version="0.0.2" />
+    <PackageReference Include="SharpXMPP" Version="0.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will fix the JID parsing issues. Thanks to @gsomix for fixing SharpXMPP!