### PR TITLE
#88: XMPP Ping

### DIFF
--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -18,11 +18,13 @@
     <Compile Include="MessageSystemTests\MessageSystemBaseTests.fs" />
     <Compile Include="Telegram\Html.fs" />
     <Compile Include="Telegram\FunogramTests.fs" />
+    <Compile Include="Xmpp\SharpXmppPingHandlerTests.fs" />
     <Compile Include="Xmpp\XmppClientFactory.fs" />
     <Compile Include="Xmpp\XmppMessageFactory.fs" />
     <Compile Include="Xmpp\XmppClientTests.fs" />
     <Compile Include="Xmpp\XmppClientRoomTests.fs" />
     <Compile Include="Xmpp\SharpXmppHelperTests.fs" />
+    <Compile Include="Xmpp\SharpXmppPingHandlerTests.fs" />
     <Compile Include="Xmpp\EmulsionXmppTests.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/Emulsion.Tests/Emulsion.Tests.fsproj
+++ b/Emulsion.Tests/Emulsion.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Xmpp\XmppClientFactory.fs" />
     <Compile Include="Xmpp\XmppMessageFactory.fs" />
     <Compile Include="Xmpp\XmppClientTests.fs" />
+    <Compile Include="Xmpp\XmppClientRoomTests.fs" />
     <Compile Include="Xmpp\SharpXmppHelperTests.fs" />
     <Compile Include="Xmpp\EmulsionXmppTests.fs" />
   </ItemGroup>

--- a/Emulsion.Tests/SettingsTests.fs
+++ b/Emulsion.Tests/SettingsTests.fs
@@ -17,7 +17,8 @@ let private testConfigText groupIdLiteral =
        ""password"": ""password"",
        ""room"": ""room"",
        ""nickname"": ""nickname"",
-       ""messageTimeout"": ""00:00:30""
+       ""messageTimeout"": ""00:00:30"",
+       ""pingTimeout"": ""00:00:30""
    },
    ""telegram"": {
        ""token"": ""token"",
@@ -36,6 +37,8 @@ let private testConfiguration = {
         RoomPassword = None
         Nickname = "nickname"
         MessageTimeout = TimeSpan.FromSeconds 30.0
+        PingInterval = None
+        PingTimeout = TimeSpan.FromSeconds 30.0
     }
     Telegram = {
         Token = "token"

--- a/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
+++ b/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
@@ -5,6 +5,7 @@ open System.Threading.Tasks
 
 open JetBrains.Lifetimes
 open SharpXMPP
+open SharpXMPP.XMPP.Client.Elements
 open Xunit
 open Xunit.Abstractions
 
@@ -85,7 +86,7 @@ type ReceiveMessageTests(outputHelper: ITestOutputHelper) =
         let client =
             XmppClientFactory.create(
                 addConnectionFailedHandler = (fun _ h -> connectionFailedHandler <- h),
-                addMessageHandler = (fun _ h -> receiveHandlers.Add h),
+                addMessageHandler = (fun _ -> receiveHandlers.Add),
                 joinMultiUserChat = fun _ _ _ ->
                     sendMessage message
                     disconnect()
@@ -159,8 +160,10 @@ type SendTests(outputHelper: ITestOutputHelper) =
 
             let client =
                 XmppClientFactory.create(
-                    addMessageHandler = (fun _ h -> messageHandlers.Add h),
-                    send = fun m -> messageId.SetResult(Option.get <| SharpXmppHelper.getMessageId m)
+                    addMessageHandler = (fun _ -> messageHandlers.Add),
+                    send = fun m ->
+                        let message = m :?> XMPPMessage
+                        messageId.SetResult(Option.get <| SharpXmppHelper.getMessageId message)
                 )
             let outgoingMessage = Authored { author = "author"; text = "text" }
 

--- a/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
+++ b/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
@@ -22,6 +22,8 @@ let private settings = {
     RoomPassword = None
     Nickname = "nickname"
     MessageTimeout = TimeSpan.FromSeconds 30.0
+    PingInterval = None
+    PingTimeout = defaultPingTimeout
 }
 
 let private runClientSynchronously settings logger client onMessage =

--- a/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
+++ b/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
@@ -74,3 +74,7 @@ let ``Message with text is not considered as empty``(): unit =
 let ``Message with proper type is a group chat message``(): unit =
     Assert.True(SharpXmppHelper.isGroupChatMessage(XmppMessageFactory.create(messageType = "groupchat")))
     Assert.False(SharpXmppHelper.isGroupChatMessage(XmppMessageFactory.create(messageType = "error")))
+
+[<Fact>]
+let ``isPong determines pong response according to the spec``(): unit =
+    Assert.False true

--- a/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
+++ b/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
@@ -8,6 +8,7 @@ open Xunit
 
 open Emulsion
 open Emulsion.Xmpp.SharpXmppHelper.Attributes
+open Emulsion.Xmpp.SharpXmppHelper.Elements
 open Emulsion.Tests.Xmpp
 open Emulsion.Xmpp
 
@@ -77,6 +78,15 @@ let ``Message with text is not considered as empty``(): unit =
 let ``Message with proper type is a group chat message``(): unit =
     Assert.True(SharpXmppHelper.isGroupChatMessage(XmppMessageFactory.create(messageType = "groupchat")))
     Assert.False(SharpXmppHelper.isGroupChatMessage(XmppMessageFactory.create(messageType = "error")))
+
+[<Fact>]
+let ``isPing determines ping IQ query according to the spec``(): unit =
+    let jid = JID("room@conference.example.com/me")
+    let ping = SharpXmppHelper.ping jid "myTest"
+    Assert.True(SharpXmppHelper.isPing ping)
+
+    ping.Element(Ping).Remove()
+    Assert.False(SharpXmppHelper.isPing ping)
 
 [<Fact>]
 let ``isPong determines pong response according to the spec``(): unit =

--- a/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
+++ b/Emulsion.Tests/Xmpp/SharpXmppHelperTests.fs
@@ -2,9 +2,12 @@ module Emulsion.Tests.Xmpp.SharpXmppHelperTests
 
 open System.Xml.Linq
 
+open SharpXMPP.XMPP
+open SharpXMPP.XMPP.Client.Elements
 open Xunit
 
 open Emulsion
+open Emulsion.Xmpp.SharpXmppHelper.Attributes
 open Emulsion.Tests.Xmpp
 open Emulsion.Xmpp
 
@@ -77,4 +80,9 @@ let ``Message with proper type is a group chat message``(): unit =
 
 [<Fact>]
 let ``isPong determines pong response according to the spec``(): unit =
-    Assert.False true
+    let jid = JID("room@conference.example.com/me")
+    let pongResponse = XMPPIq(XMPPIq.IqTypes.result, "myTest")
+    pongResponse.SetAttributeValue(From, jid.FullJid)
+
+    Assert.True(SharpXmppHelper.isPong jid "myTest" pongResponse)
+    Assert.False(SharpXmppHelper.isPong jid "thyTest" pongResponse)

--- a/Emulsion.Tests/Xmpp/SharpXmppPingHandlerTests.fs
+++ b/Emulsion.Tests/Xmpp/SharpXmppPingHandlerTests.fs
@@ -1,0 +1,49 @@
+﻿module Emulsion.Tests.Xmpp.SharpXmppPingHandlerTests
+
+open System.IO
+open System.Xml
+
+open SharpXMPP
+open SharpXMPP.XMPP
+open SharpXMPP.XMPP.Client.Elements
+open Xunit
+
+open Emulsion.Xmpp
+open Emulsion.Xmpp.SharpXmppHelper.Attributes
+
+let private handler = SharpXmppPingHandler()
+type private MockedXmppTcpConnection() as this =
+    inherit XmppTcpConnection("", JID(), "")
+    do this.Writer <- XmlWriter.Create Stream.Null
+
+[<Fact>]
+let ``SharpXmppPingHandler handles a ping request``() =
+    let jid = JID "me@example.com"
+    let request = SharpXmppHelper.ping jid "test"
+    request.SetAttributeValue(From, "they@example.com")
+
+    use connection = new MockedXmppTcpConnection()
+    Assert.True(handler.Handle(connection, request))
+
+[<Fact>]
+let ``SharpXmppPingHandler sends a pong response``() =
+    let jid = JID "me@example.com"
+    let request = SharpXmppHelper.ping jid "test"
+    request.SetAttributeValue(From, "they@example.com")
+
+    let elements = ResizeArray()
+    use connection = new MockedXmppTcpConnection()
+    connection.add_Element(fun _ e -> elements.Add e.Stanza)
+
+    Assert.True(handler.Handle(connection, request))
+    let pong = Seq.exactlyOne elements
+    Assert.True(SharpXmppHelper.isPong jid "test" (pong :?> XMPPIq))
+
+[<Fact>]
+let ``SharpXmppPingHandler ignores a non-ping query``() =
+    let elements = ResizeArray()
+    use connection = new MockedXmppTcpConnection()
+    connection.add_Element(fun _ e -> elements.Add e.Stanza)
+
+    Assert.False(handler.Handle(connection, XMPPIq(XMPPIq.IqTypes.get)))
+    Assert.Empty elements

--- a/Emulsion.Tests/Xmpp/XmppClientFactory.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientFactory.fs
@@ -7,12 +7,14 @@ type XmppClientFactory =
                          ?joinMultiUserChat,
                          ?send,
                          ?addConnectionFailedHandler,
+                         ?addIqHandler,
                          ?addPresenceHandler,
                          ?addMessageHandler): IXmppClient =
         let connect = defaultArg connect <| fun () -> async { return () }
         let joinMultiUserChat = defaultArg joinMultiUserChat <| fun _ _ _ -> ()
         let send = defaultArg send ignore
         let addConnectionFailedHandler = defaultArg addConnectionFailedHandler <| fun _ _ -> ()
+        let addIqHandler = defaultArg addIqHandler <| fun _ _ -> ()
         let addPresenceHandler = defaultArg addPresenceHandler <| fun _ _ -> ()
         let addMessageHandler = defaultArg addMessageHandler <| fun _ _ -> ()
         { new IXmppClient with
@@ -22,7 +24,7 @@ type XmppClientFactory =
             member _.AddConnectionFailedHandler lt handler = addConnectionFailedHandler lt handler
             member _.AddSignedInHandler _ _ = ()
             member _.AddElementHandler _ _ = ()
-            member _.AddIqHandler _ _ = ()
+            member _.AddIqHandler lt handler = addIqHandler lt handler
             member _.AddPresenceHandler lt handler = addPresenceHandler lt handler
             member _.AddMessageHandler lt handler = addMessageHandler lt handler
         }

--- a/Emulsion.Tests/Xmpp/XmppClientFactory.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientFactory.fs
@@ -22,6 +22,7 @@ type XmppClientFactory =
             member _.AddConnectionFailedHandler lt handler = addConnectionFailedHandler lt handler
             member _.AddSignedInHandler _ _ = ()
             member _.AddElementHandler _ _ = ()
+            member _.AddIqHandler _ _ = ()
             member _.AddPresenceHandler lt handler = addPresenceHandler lt handler
             member _.AddMessageHandler lt handler = addMessageHandler lt handler
         }

--- a/Emulsion.Tests/Xmpp/XmppClientFactory.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientFactory.fs
@@ -6,25 +6,25 @@ type XmppClientFactory =
     static member create(?connect,
                          ?joinMultiUserChat,
                          ?send,
+                         ?sendIqQuery,
                          ?addConnectionFailedHandler,
-                         ?addIqHandler,
                          ?addPresenceHandler,
                          ?addMessageHandler): IXmppClient =
         let connect = defaultArg connect <| fun () -> async { return () }
         let joinMultiUserChat = defaultArg joinMultiUserChat <| fun _ _ _ -> ()
         let send = defaultArg send ignore
         let addConnectionFailedHandler = defaultArg addConnectionFailedHandler <| fun _ _ -> ()
-        let addIqHandler = defaultArg addIqHandler <| fun _ _ -> ()
+        let sendIqQuery = defaultArg sendIqQuery <| fun _ _ _ -> ()
         let addPresenceHandler = defaultArg addPresenceHandler <| fun _ _ -> ()
         let addMessageHandler = defaultArg addMessageHandler <| fun _ _ -> ()
         { new IXmppClient with
             member _.Connect() = connect()
             member _.JoinMultiUserChat roomJid nickname password = joinMultiUserChat roomJid nickname password
             member _.Send m = send m
+            member _.SendIqQuery lt iq handler = sendIqQuery lt iq handler
             member _.AddConnectionFailedHandler lt handler = addConnectionFailedHandler lt handler
             member _.AddSignedInHandler _ _ = ()
             member _.AddElementHandler _ _ = ()
-            member _.AddIqHandler lt handler = addIqHandler lt handler
             member _.AddPresenceHandler lt handler = addPresenceHandler lt handler
             member _.AddMessageHandler lt handler = addMessageHandler lt handler
         }

--- a/Emulsion.Tests/Xmpp/XmppClientRoomTests.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientRoomTests.fs
@@ -1,0 +1,145 @@
+﻿namespace Emulsion.Tests.Xmpp
+
+open System
+open System.Threading.Tasks
+open System.Xml.Linq
+
+open JetBrains.Lifetimes
+open SharpXMPP.XMPP
+open SharpXMPP.XMPP.Client.Elements
+open Xunit
+open Xunit.Abstractions
+
+open Emulsion
+open Emulsion.Xmpp
+open Emulsion.Xmpp.SharpXmppHelper.Attributes
+open Emulsion.Xmpp.SharpXmppHelper.Elements
+open Emulsion.Tests.TestUtils.Logging
+
+type XmppClientRoomTests(output: ITestOutputHelper) =
+    let logger = xunitLogger output
+
+    let testRoomInfo = {
+        RoomJid = JID("room@conference.example.org")
+        Nickname = "testuser"
+        Password = None
+        Ping = {| Interval = None
+                  Timeout = Settings.defaultPingTimeout |}
+    }
+
+    let createPresenceFor (roomJid: JID) nickname =
+        let presence = XMPPPresence()
+        let participantJid = JID(roomJid.FullJid)
+        participantJid.Resource <- nickname
+        presence.SetAttributeValue(From, participantJid.FullJid)
+        presence
+
+    let createSelfPresence roomJid nickname (statusCode: int) =
+        let presence = createPresenceFor roomJid nickname
+        let x = XElement X
+        let status = XElement Status
+        status.SetAttributeValue(Code, statusCode)
+        x.Add status
+        presence.Add x
+        presence
+
+    let createErrorPresence roomJid nickname errorXml =
+        let presence = createPresenceFor roomJid nickname
+        presence.SetAttributeValue(Type, "error")
+        let error = XElement Error
+        let errorChild = XElement.Parse errorXml
+        error.Add errorChild
+        presence.Add error
+        presence
+
+    let createLeavePresence roomJid nickname =
+        let presence = createSelfPresence roomJid nickname 307
+        presence.SetAttributeValue(Type, "unavailable")
+        presence
+
+    let sendPresence presence handlers =
+        Seq.iter (fun h -> h presence) handlers
+
+    let createPresenceHandlingClient() =
+        let mutable presenceHandlers = ResizeArray()
+        XmppClientFactory.create(
+            addPresenceHandler = (fun _ -> presenceHandlers.Add),
+            joinMultiUserChat = fun roomJid nickname _ ->
+                sendPresence (createSelfPresence roomJid nickname 110) presenceHandlers
+        ), presenceHandlers
+
+    [<Fact>]
+    member _.``enterRoom function calls JoinMultiUserChat``(): unit =
+        let mutable called = false
+        let mutable presenceHandlers = ResizeArray()
+        let client =
+            XmppClientFactory.create(
+                addPresenceHandler = (fun _ -> presenceHandlers.Add),
+                joinMultiUserChat = fun roomJid nickname _ ->
+                    called <- true
+                    Seq.iter (fun h -> h (createSelfPresence roomJid nickname 110)) presenceHandlers
+            )
+        Lifetime.Using(fun lt ->
+            Async.RunSynchronously <| XmppClient.enterRoom logger client lt testRoomInfo |> ignore
+            Assert.True called
+        )
+
+    [<Fact>]
+    member _.``enterRoom throws an exception in case of an error presence``(): unit =
+        let mutable presenceHandlers = ResizeArray()
+        let client =
+            XmppClientFactory.create(
+                addPresenceHandler = (fun _ -> presenceHandlers.Add),
+                joinMultiUserChat = fun roomJid nickname _ ->
+                    sendPresence (createErrorPresence roomJid nickname "<jid-malformed xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" />") presenceHandlers
+            )
+        Lifetime.Using(fun lt ->
+            let ae = Assert.Throws<AggregateException>(fun () ->
+                Async.RunSynchronously <| XmppClient.enterRoom logger client lt testRoomInfo |> ignore
+            )
+            let ex = Seq.exactlyOne ae.InnerExceptions
+            Assert.Contains("<jid-malformed xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" />", ex.Message)
+        )
+
+    [<Fact>]
+    member _.``Lifetime returned from enterRoom terminates by a room leave presence``(): unit =
+        let (client, presenceHandlers) = createPresenceHandlingClient()
+        Lifetime.Using(fun lt ->
+            let roomLt = Async.RunSynchronously <| XmppClient.enterRoom logger client lt testRoomInfo
+            Assert.True roomLt.IsAlive
+            sendPresence (createLeavePresence testRoomInfo.RoomJid testRoomInfo.Nickname) presenceHandlers
+            Assert.False roomLt.IsAlive
+        )
+
+    [<Fact>]
+    member _.``Lifetime returned from enterRoom terminates by an external lifetime termination``(): unit =
+        let (client, _) = createPresenceHandlingClient()
+        use ld = Lifetime.Define()
+        let lt = ld.Lifetime
+        let roomLt = Async.RunSynchronously <| XmppClient.enterRoom logger client lt testRoomInfo
+        Assert.True roomLt.IsAlive
+        ld.Terminate()
+        Assert.False roomLt.IsAlive
+
+    [<Fact>]
+    member _.``client sends a ping after room connection``(): Task =
+        let (client, _) = createPresenceHandlingClient()
+        upcast Lifetime.UsingAsync(fun lt ->
+            async {
+                let mutable pingSent = false
+                let! _ = XmppClient.enterRoom logger client lt testRoomInfo
+                Assert.True pingSent
+            } |> Async.StartAsTask
+        )
+
+    [<Fact>]
+    member _.``client doesn't send ping before finishing joining the room``(): unit =
+        Assert.True false
+
+    [<Fact>]
+    member _.``client disconnects on failing a ping request``(): unit =
+        Assert.True false
+
+    [<Fact>]
+    member _.``client doesn't disconnect on successful ping request``(): unit =
+        Assert.True false

--- a/Emulsion.Tests/Xmpp/XmppClientTests.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientTests.fs
@@ -11,47 +11,13 @@ open SharpXMPP.XMPP.Client.Elements
 open Xunit
 
 open Emulsion.Xmpp
-open Emulsion.Xmpp.SharpXmppHelper.Attributes
 open Emulsion.Xmpp.SharpXmppHelper.Elements
 
-let private createPresenceFor (roomJid: JID) nickname =
-    let presence = XMPPPresence()
-    let participantJid = JID(roomJid.FullJid)
-    participantJid.Resource <- nickname
-    presence.SetAttributeValue(From, participantJid.FullJid)
-    presence
-
-let private createSelfPresence roomJid nickname (statusCode: int) =
-    let presence = createPresenceFor roomJid nickname
-    let x = XElement X
-    let status = XElement Status
-    status.SetAttributeValue(Code, statusCode)
-    x.Add status
-    presence.Add x
-    presence
-
-let private createErrorPresence roomJid nickname errorXml =
-    let presence = createPresenceFor roomJid nickname
-    presence.SetAttributeValue(Type, "error")
-    let error = XElement Error
-    let errorChild = XElement.Parse errorXml
-    error.Add errorChild
-    presence.Add error
-    presence
-
-let private createLeavePresence roomJid nickname =
-    let presence = createSelfPresence roomJid nickname 307
-    presence.SetAttributeValue(Type, "unavailable")
-    presence
-
-let private sendPresence presence handlers =
-    Seq.iter (fun h -> h presence) handlers
-
-let private createErrorMessage (message: XMPPMessage) errorXml =
+let private createErrorMessage (message: XElement) errorXml =
     // An error message is an exact copy of the original with the "error" element added:
     let errorMessage = XMPPMessage()
     message.Attributes() |> Seq.iter (fun a -> errorMessage.SetAttributeValue(a.Name, a.Value))
-    message.Elements() |> Seq.iter (fun e -> errorMessage.Add e)
+    message.Elements() |> Seq.iter errorMessage.Add
 
     let error = XElement Error
     let errorChild = XElement.Parse errorXml
@@ -75,82 +41,13 @@ let ``connect function returns a lifetime terminated whenever the ConnectionFail
     callback(ConnFailedArgs())
     Assert.False lt.IsAlive
 
-[<Fact>]
-let ``enterRoom function calls JoinMultiUserChat``(): unit =
-    let mutable called = false
-    let mutable presenceHandlers = ResizeArray()
-    let client =
-        XmppClientFactory.create(
-            addPresenceHandler = (fun _ h -> presenceHandlers.Add h),
-            joinMultiUserChat = fun roomJid nickname _ ->
-                called <- true
-                Seq.iter (fun h -> h (createSelfPresence roomJid nickname 110)) presenceHandlers
-        )
-    let roomInfo = { RoomJid = JID("room@conference.example.org"); Nickname = "testuser"; Password = None }
-    Lifetime.Using(fun lt ->
-        Async.RunSynchronously <| XmppClient.enterRoom client lt roomInfo |> ignore
-        Assert.True called
-    )
-
-[<Fact>]
-let ``enterRoom throws an exception in case of an error presence``(): unit =
-    let mutable presenceHandlers = ResizeArray()
-    let client =
-        XmppClientFactory.create(
-            addPresenceHandler = (fun _ h -> presenceHandlers.Add h),
-            joinMultiUserChat = fun roomJid nickname _ ->
-                sendPresence (createErrorPresence roomJid nickname "<jid-malformed xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" />") presenceHandlers
-        )
-    let roomInfo = { RoomJid = JID("room@conference.example.org"); Nickname = "testuser"; Password = None }
-    Lifetime.Using(fun lt ->
-        let ae = Assert.Throws<AggregateException>(fun () ->
-            Async.RunSynchronously <| XmppClient.enterRoom client lt roomInfo |> ignore
-        )
-        let ex = Seq.exactlyOne ae.InnerExceptions
-        Assert.Contains("<jid-malformed xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" />", ex.Message)
-    )
-
-[<Fact>]
-let ``Lifetime returned from enterRoom terminates by a room leave presence``(): unit =
-    let mutable presenceHandlers = ResizeArray()
-    let client =
-        XmppClientFactory.create(
-            addPresenceHandler = (fun _ h -> presenceHandlers.Add h),
-            joinMultiUserChat = fun roomJid nickname _ ->
-                sendPresence (createSelfPresence roomJid nickname 110) presenceHandlers
-        )
-    let roomInfo = { RoomJid = JID("room@conference.example.org"); Nickname = "testuser"; Password = None }
-    Lifetime.Using(fun lt ->
-        let roomLt = Async.RunSynchronously <| XmppClient.enterRoom client lt roomInfo
-        Assert.True roomLt.IsAlive
-        sendPresence (createLeavePresence roomInfo.RoomJid roomInfo.Nickname) presenceHandlers
-        Assert.False roomLt.IsAlive
-    )
-
-[<Fact>]
-let ``Lifetime returned from enterRoom terminates by an external lifetime termination``(): unit =
-    let mutable presenceHandlers = ResizeArray()
-    let client =
-        XmppClientFactory.create(
-            addPresenceHandler = (fun _ h -> presenceHandlers.Add h),
-            joinMultiUserChat = fun roomJid nickname _ ->
-                sendPresence (createSelfPresence roomJid nickname 110) presenceHandlers
-        )
-    let roomInfo = { RoomJid = JID("room@conference.example.org"); Nickname = "testuser"; Password = None }
-    use ld = Lifetime.Define()
-    let lt = ld.Lifetime
-    let roomLt = Async.RunSynchronously <| XmppClient.enterRoom client lt roomInfo
-    Assert.True roomLt.IsAlive
-    ld.Terminate()
-    Assert.False roomLt.IsAlive
-
 let private sendRoomMessage client lt messageInfo =
     XmppClient.sendRoomMessage client lt Emulsion.Settings.defaultMessageTimeout messageInfo
 
 [<Fact>]
 let ``sendRoomMessage calls Send method on the client``(): unit =
     let mutable message = Unchecked.defaultof<XMPPMessage>
-    let client = XmppClientFactory.create(send = fun m -> message <- m)
+    let client = XmppClientFactory.create(send = fun m -> message <- m :?> XMPPMessage)
     let messageInfo = { RecipientJid = JID("room@conference.example.org"); Text = "foo bar" }
     Lifetime.Using(fun lt ->
         Async.RunSynchronously <| sendRoomMessage client lt messageInfo |> ignore
@@ -165,7 +62,7 @@ let ``sendRoomMessage's result gets resolved after the message receival``(): uni
     let client =
         XmppClientFactory.create(
             addMessageHandler = (fun _ h -> messageHandler <- h),
-            send = fun m -> message <- m
+            send = fun m -> message <- m :?> XMPPMessage
         )
     let messageInfo = { RecipientJid = JID("room@conference.example.org"); Text = "foo bar" }
     Lifetime.Using(fun lt ->
@@ -218,7 +115,7 @@ let ``sendRoomMessage's result gets terminated after parent lifetime termination
     let deliveryTask = Async.StartAsTask deliveryInfo.Delivery
     Assert.False deliveryTask.IsCompleted
     ld.Terminate()
-    Assert.Throws<TaskCanceledException>(fun () -> deliveryTask.GetAwaiter().GetResult()) |> ignore
+    Assert.Throws<TaskCanceledException>(deliveryTask.GetAwaiter().GetResult) |> ignore
 
 [<Fact>]
 let ``awaitMessageDelivery just returns an async from the delivery info``(): unit =

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -41,6 +41,6 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="SharpXMPP" Version="0.2.0-pre" />
+    <PackageReference Include="SharpXMPP" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="EmulsionSettings.fs" />
+    <Compile Include="Settings.fs" />
     <Compile Include="Message.fs" />
     <Compile Include="MessageSender.fs" />
     <Compile Include="MessageSystem.fs" />

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="Xmpp\Types.fs" />
     <Compile Include="Xmpp/SharpXmppHelper.fs" />
     <Compile Include="Xmpp\XmppClient.fs" />
+    <Compile Include="Xmpp\SharpXmppPingHandler.fs" />
     <Compile Include="Xmpp\SharpXmppClient.fs" />
     <Compile Include="Xmpp\EmulsionXmpp.fs" />
     <Compile Include="Xmpp\XmppMessageSystem.fs" />
@@ -40,6 +41,6 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="SharpXMPP" Version="0.1.0" />
+    <PackageReference Include="SharpXMPP" Version="0.2.0-pre" />
   </ItemGroup>
 </Project>

--- a/Emulsion/Xmpp/EmulsionXmpp.fs
+++ b/Emulsion/Xmpp/EmulsionXmpp.fs
@@ -51,9 +51,15 @@ let run (settings: XmppSettings)
     addMessageHandler client sessionLifetime settings messageReceiver
     logger.Information "Client handler initialized"
 
-    let roomInfo = { RoomJid = JID(settings.Room); Nickname = settings.Nickname; Password = settings.RoomPassword }
+    let roomInfo = {
+        RoomJid = JID(settings.Room)
+        Nickname = settings.Nickname
+        Password = settings.RoomPassword
+        Ping = {| Interval = settings.PingInterval
+                  Timeout = settings.PingTimeout |}
+    }
     logger.Information("Entering the room {RoomInfo}", roomInfo)
-    let! roomLifetime = enterRoom client sessionLifetime roomInfo
+    let! roomLifetime = enterRoom logger client sessionLifetime roomInfo
     logger.Information "Entered the room"
 
     return async {

--- a/Emulsion/Xmpp/SharpXmppClient.fs
+++ b/Emulsion/Xmpp/SharpXmppClient.fs
@@ -47,7 +47,9 @@ type Wrapper(client: XmppClient) =
             lt.OnTermination(fun () -> client.remove_Message handlerDelegate) |> ignore
 
 let create (settings: XmppSettings): XmppClient =
-    new XmppClient(JID(settings.Login), settings.Password)
+    let client = new XmppClient(JID(settings.Login), settings.Password)
+    client.IqManager.PayloadHandlers.Add(SharpXmppPingHandler())
+    client
 
 let wrap(client: XmppClient): IXmppClient =
     upcast Wrapper client

--- a/Emulsion/Xmpp/SharpXmppClient.fs
+++ b/Emulsion/Xmpp/SharpXmppClient.fs
@@ -3,37 +3,50 @@ module Emulsion.Xmpp.SharpXmppClient
 
 open SharpXMPP
 open SharpXMPP.XMPP
+open SharpXMPP.XMPP.Client.Elements
 
 open Emulsion.Xmpp
 open Emulsion.Xmpp.XmppClient
 open Emulsion.Settings
 
 type Wrapper(client: XmppClient) =
+    let socketWriterLock = obj()
+
     interface IXmppClient with
         member _.Connect() = async {
             let! ct = Async.CancellationToken
             return! Async.AwaitTask(client.ConnectAsync ct)
         }
         member _.JoinMultiUserChat roomJid nickname password = SharpXmppHelper.joinRoom client roomJid.BareJid nickname password
-        member _.Send message = client.Send message
+        member _.Send message =
+            lock socketWriterLock (fun () ->
+                client.Send message
+            )
         member _.AddSignedInHandler lt handler =
-            let handlerDelegate = XmppClient.SignedInHandler(fun _ args -> handler args)
+            let handlerDelegate = XmppClient.SignedInHandler(fun _ -> handler)
             client.add_SignedIn handlerDelegate
             lt.OnTermination(fun () -> client.remove_SignedIn handlerDelegate) |> ignore
         member _.AddElementHandler lt handler =
-            let handlerDelegate = XmppClient.ElementHandler(fun _ args -> handler args)
+            let handlerDelegate = XmppClient.ElementHandler(fun _ -> handler)
             client.add_Element handlerDelegate
             lt.OnTermination(fun () -> client.remove_Element handlerDelegate) |> ignore
+        member this.AddIqHandler lt handler =
+            // TODO[F]: Make XmppConnection.Iq event public and get rid of type filter here
+            (this :> IXmppClient).AddElementHandler lt (fun e ->
+                match e.Stanza with
+                | :? XMPPIq as iq -> handler iq
+                | _ -> ()
+            )
         member _.AddConnectionFailedHandler lt handler =
-            let handlerDelegate = XmppClient.ConnectionFailedHandler(fun _ args -> handler args)
+            let handlerDelegate = XmppClient.ConnectionFailedHandler(fun _ -> handler)
             client.add_ConnectionFailed handlerDelegate
             lt.OnTermination(fun () -> client.remove_ConnectionFailed handlerDelegate) |> ignore
         member _.AddPresenceHandler lt handler =
-            let handlerDelegate = XmppClient.PresenceHandler(fun _ args -> handler args)
+            let handlerDelegate = XmppClient.PresenceHandler(fun _ -> handler)
             client.add_Presence handlerDelegate
             lt.OnTermination(fun () -> client.remove_Presence handlerDelegate) |> ignore
         member _.AddMessageHandler lt handler =
-            let handlerDelegate = XmppClient.MessageHandler(fun _ args -> handler args)
+            let handlerDelegate = XmppClient.MessageHandler(fun _ -> handler)
             client.add_Message handlerDelegate
             lt.OnTermination(fun () -> client.remove_Message handlerDelegate) |> ignore
 

--- a/Emulsion/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion/Xmpp/SharpXmppHelper.fs
@@ -6,8 +6,8 @@ open System.Xml.Linq
 
 open SharpXMPP
 open SharpXMPP.XMPP
-open SharpXMPP.XMPP.Client.MUC.Bookmarks.Elements
 open SharpXMPP.XMPP.Client.Elements
+open SharpXMPP.XMPP.Client.MUC.Bookmarks.Elements
 
 open Emulsion
 open Emulsion.Xmpp
@@ -59,16 +59,16 @@ let message (id: string) (toAddr: string) (text: string): XMPPMessage =
     m.Add(body)
     m
 
-let ping (roomInfo: RoomInfo) (id: string): XMPPIq =
+let ping (jid: JID) (id: string): XMPPIq =
     let iq = XMPPIq()
     iq.SetAttributeValue(Id, id)
     iq.IqType <- XMPPIq.IqTypes.get
-    iq.To <- JID(roomInfo.RoomJid.BareJid, Resource = roomInfo.Nickname)
+    iq.To <- jid
     iq.Add(XElement(Ping))
     iq
 
-let isPong (pingId: string) (iq: XMPPIq): bool =
-    failwith "TODO"
+let isPong (from: JID) (pingId: string) (iq: XMPPIq): bool =
+     iq.IqType = XMPPIq.IqTypes.result && iq.From.FullJid = from.FullJid && iq.ID = pingId
 
 let private getAttributeValue (element : XElement) attributeName =
     let attribute = element.Attribute(attributeName)

--- a/Emulsion/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion/Xmpp/SharpXmppHelper.fs
@@ -60,10 +60,7 @@ let message (id: string) (toAddr: string) (text: string): XMPPMessage =
     m
 
 let ping (jid: JID) (id: string): XMPPIq =
-    let iq = XMPPIq()
-    iq.SetAttributeValue(Id, id)
-    iq.IqType <- XMPPIq.IqTypes.get
-    iq.To <- jid
+    let iq = XMPPIq(XMPPIq.IqTypes.get, id, To = jid)
     iq.Add(XElement(Ping))
     iq
 

--- a/Emulsion/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion/Xmpp/SharpXmppHelper.fs
@@ -64,6 +64,10 @@ let ping (jid: JID) (id: string): XMPPIq =
     iq.Add(XElement(Ping))
     iq
 
+let isPing(iq: XMPPIq): bool =
+    if iq.IqType <> XMPPIq.IqTypes.get then false
+    else iq.Element Ping <> null
+
 let isPong (from: JID) (pingId: string) (iq: XMPPIq): bool =
      iq.IqType = XMPPIq.IqTypes.result && iq.From.FullJid = from.FullJid && iq.ID = pingId
 

--- a/Emulsion/Xmpp/SharpXmppHelper.fs
+++ b/Emulsion/Xmpp/SharpXmppHelper.fs
@@ -14,6 +14,7 @@ open Emulsion.Xmpp
 
 module Namespaces =
     let MucUser = "http://jabber.org/protocol/muc#user"
+    let Ping = "urn:xmpp:ping"
 
 module Attributes =
     let Code = XName.Get "code"
@@ -31,6 +32,7 @@ module Elements =
     let Error = XName.Get("error", Namespaces.JabberClient)
     let Nick = XName.Get("nick", Namespaces.StorageBookmarks)
     let Password = XName.Get("password", Namespaces.StorageBookmarks)
+    let Ping = XName.Get("ping", Namespaces.Ping)
     let Status = XName.Get("status", Namespaces.MucUser)
     let X = XName.Get("x", Namespaces.MucUser)
 
@@ -56,6 +58,17 @@ let message (id: string) (toAddr: string) (text: string): XMPPMessage =
     body.Value <- text
     m.Add(body)
     m
+
+let ping (roomInfo: RoomInfo) (id: string): XMPPIq =
+    let iq = XMPPIq()
+    iq.SetAttributeValue(Id, id)
+    iq.IqType <- XMPPIq.IqTypes.get
+    iq.To <- JID(roomInfo.RoomJid.BareJid, Resource = roomInfo.Nickname)
+    iq.Add(XElement(Ping))
+    iq
+
+let isPong (pingId: string) (iq: XMPPIq): bool =
+    failwith "TODO"
 
 let private getAttributeValue (element : XElement) attributeName =
     let attribute = element.Attribute(attributeName)

--- a/Emulsion/Xmpp/SharpXmppPingHandler.fs
+++ b/Emulsion/Xmpp/SharpXmppPingHandler.fs
@@ -1,0 +1,13 @@
+﻿namespace Emulsion.Xmpp
+
+open SharpXMPP.XMPP.Client
+
+type SharpXmppPingHandler() =
+    inherit PayloadHandler()
+
+    override _.Handle(connection, element) =
+        if SharpXmppHelper.isPing element then
+            connection.Send(element.Reply())
+            true
+        else
+            false

--- a/Emulsion/Xmpp/Types.fs
+++ b/Emulsion/Xmpp/Types.fs
@@ -1,5 +1,6 @@
 namespace Emulsion.Xmpp
 
+open System
 open System.Xml.Linq
 
 open SharpXMPP.XMPP
@@ -15,6 +16,8 @@ type RoomInfo = {
     RoomJid: JID
     Nickname: string
     Password: string option
+    Ping: {| Interval: TimeSpan option
+             Timeout: TimeSpan |}
 }
 
 type MessageInfo = {

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -91,7 +91,7 @@ let private startPingActivity (logger: ILogger)
                            .OnTermination(fun () ->
                                 let pongReceived = Volatile.Read &pongReceived
                                 if not pongReceived then
-                                    logger.Warning("Ping message not received in {Time}: terminating room {Room}",
+                                    logger.Warning("Pong message not received in {Time}: terminating room {Room}",
                                                    roomInfo.Ping.Timeout,
                                                    roomInfo.RoomJid)
                                     roomLifetimeDefinition.Terminate()
@@ -100,6 +100,7 @@ let private startPingActivity (logger: ILogger)
                     client.SendIqQuery pingLifetime pingMessage (fun response ->
                         if SharpXmppHelper.isPong jid pingId response then
                             Volatile.Write(&pongReceived, true)
+                            use __ = pingLifetime.UsingAllowTerminationUnderExecution()
                             pingLifetimeDefinition.Terminate()
                     )
 

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -2,9 +2,11 @@
 module Emulsion.Xmpp.XmppClient
 
 open System
+open System.Threading
+open System.Xml.Linq
 
 open JetBrains.Lifetimes
-
+open Serilog
 open SharpXMPP
 open SharpXMPP.XMPP
 open SharpXMPP.XMPP.Client.Elements
@@ -12,13 +14,17 @@ open SharpXMPP.XMPP.Client.Elements
 open Emulsion
 open Emulsion.Xmpp
 
+/// Note: all the subscription methods should be free-threaded, and should expect the lifetime to be terminated in a
+/// free-threaded way (i.e. lifetime termination may come from any thread in the system).
 type IXmppClient =
     abstract member Connect: unit -> Async<unit>
     abstract member JoinMultiUserChat: roomJid: JID -> nickname: string -> password: string option -> unit
-    abstract member Send: XMPPMessage -> unit
+    /// Sends an XMPP message. Should be free-threaded.
+    abstract member Send: XElement -> unit
     abstract member AddConnectionFailedHandler: Lifetime -> (ConnFailedArgs -> unit) -> unit
     abstract member AddSignedInHandler: Lifetime -> (SignedInArgs -> unit) -> unit
     abstract member AddElementHandler: Lifetime -> (ElementArgs -> unit) -> unit
+    abstract member AddIqHandler: Lifetime -> (XMPPIq -> unit) -> unit
     abstract member AddPresenceHandler: Lifetime -> (XMPPPresence -> unit) -> unit
     abstract member AddMessageHandler: Lifetime -> (XMPPMessage -> unit) -> unit
 
@@ -51,43 +57,93 @@ let private extractPresenceException (roomInfo: RoomInfo) (presence: XMPPPresenc
         |> Option.map (fun e -> Exception(sprintf "Error: %A" e))
     else None
 
+let private newMessageId(): string =
+    Guid.NewGuid().ToString()
+
+let private startPingActivity (logger: ILogger) (client: IXmppClient) (roomLifetimeDefinition: LifetimeDefinition) roomInfo =
+    roomInfo.Ping.Interval |> Option.iter (fun pingInterval ->
+        let pingTimeout = roomInfo.Ping.Timeout
+        if pingInterval <= pingTimeout then
+            failwithf "Ping interval of %A should be greater than ping timeout of %A" pingInterval pingTimeout
+            // (otherwise, `use pingLifetimeDefinition` below would create lifetime conflict: it could've been
+            // terminated earlier than the ping timeout ends, which will break ping logic)
+
+        let activityLifetime = roomLifetimeDefinition.Lifetime
+        Async.Start (async {
+            while true do
+                try
+                    let pingId = newMessageId()
+                    let pingMessage = SharpXmppHelper.ping roomInfo pingId
+                    let mutable pongReceived = false
+
+                    use pingLifetimeDefinition = activityLifetime.CreateNested()
+                    let pingLifetime =
+                        pingLifetimeDefinition.Lifetime
+                           .CreateTerminatedAfter(pingTimeout)
+                           .OnTermination(fun () ->
+                                let pongReceived = Volatile.Read &pongReceived
+                                if not pongReceived then
+                                    logger.Warning("Ping message not received in {Time}: terminating room {Room}",
+                                                   roomInfo.Ping.Timeout,
+                                                   roomInfo.RoomJid)
+                                    roomLifetimeDefinition.Terminate()
+                            )
+
+                    client.AddIqHandler pingLifetime (fun iq ->
+                        if SharpXmppHelper.isPong pingId iq then
+                            Volatile.Write(&pongReceived, true)
+                            pingLifetimeDefinition.Terminate()
+                    )
+
+                    client.Send pingMessage
+
+                    do! Async.Sleep(int pingInterval.TotalMilliseconds)
+                with
+                | ex ->
+                    logger.Error(ex, "Exception in ping activity for {Room}: {Message}", roomInfo.RoomJid, ex.Message)
+                    roomLifetimeDefinition.Terminate()
+        }, activityLifetime.ToCancellationToken())
+    )
+
 /// Enter the room, returning the in-room lifetime. Will terminate if kicked or left the room.
-let enterRoom (client: IXmppClient) (lifetime: Lifetime) (roomInfo: RoomInfo): Async<Lifetime> = async {
-    use connectionLifetimeDefinition = lifetime.CreateNested()
-    let connectionLifetime = connectionLifetimeDefinition.Lifetime
+let enterRoom (logger: ILogger) (client: IXmppClient) (lifetime: Lifetime) (roomInfo: RoomInfo): Async<Lifetime> =
+    async {
+        use connectionLifetimeDefinition = lifetime.CreateNested()
+        let connectionLifetime = connectionLifetimeDefinition.Lifetime
 
-    let roomLifetimeDefinition = lifetime.CreateNested()
-    let roomLifetime = roomLifetimeDefinition.Lifetime
+        let roomLifetimeDefinition = lifetime.CreateNested()
+        let roomLifetime = roomLifetimeDefinition.Lifetime
 
-    let tcs = connectionLifetime.CreateTaskCompletionSource()
+        let tcs = connectionLifetime.CreateTaskCompletionSource()
 
-    // Success and error handlers:
-    client.AddPresenceHandler connectionLifetime (fun presence ->
-        if isSelfPresence roomInfo presence
-        then tcs.SetResult()
-        else
-            match extractPresenceException roomInfo presence with
-            | Some ex -> tcs.SetException ex
-            | None -> ()
-    )
+        // Success and error handlers:
+        client.AddPresenceHandler connectionLifetime (fun presence ->
+            if isSelfPresence roomInfo presence
+            then tcs.SetResult()
+            else
+                match extractPresenceException roomInfo presence with
+                | Some ex -> tcs.SetException ex
+                | None -> ()
+        )
 
-    // Room leave handler:
-    client.AddPresenceHandler roomLifetime (fun presence ->
-        if isLeavePresence roomInfo presence
-        then roomLifetimeDefinition.Terminate()
-    )
+        // Room leave handler:
+        client.AddPresenceHandler roomLifetime (fun presence ->
+            if isLeavePresence roomInfo presence
+            then roomLifetimeDefinition.Terminate()
+        )
 
-    try
-        // Start the join process, wait for a result:
-        client.JoinMultiUserChat roomInfo.RoomJid roomInfo.Nickname roomInfo.Password
-        do! Async.AwaitTask tcs.Task
-        return roomLifetime
-    with
-    | ex ->
-        // In case of an error, terminate the room lifetime (but leave it intact in case of success):
-        roomLifetimeDefinition.Terminate()
-        return ExceptionUtils.reraise ex
-}
+        try
+            // Start the join process, wait for a result:
+            client.JoinMultiUserChat roomInfo.RoomJid roomInfo.Nickname roomInfo.Password
+            do! Async.AwaitTask tcs.Task
+            startPingActivity logger client roomLifetimeDefinition roomInfo
+            return roomLifetime
+        with
+        | ex ->
+            // In case of an error, terminate the room lifetime (but leave it intact in case of success):
+            roomLifetimeDefinition.Terminate()
+            return ExceptionUtils.reraise ex
+    }
 
 let private hasMessageId messageId message =
     SharpXmppHelper.getMessageId message = Some messageId
@@ -120,9 +176,6 @@ let private awaitMessageReceival (client: IXmppClient) (lifetime: Lifetime) (tim
     | _ ->
         messageLifetimeDefinition.Dispose()
         reraise()
-
-let private newMessageId(): string =
-    Guid.NewGuid().ToString()
 
 /// Sends the message to the room. Returns an object that allows to track the message receival.
 let sendRoomMessage (client: IXmppClient)

--- a/Emulsion/Xmpp/XmppClient.fs
+++ b/Emulsion/Xmpp/XmppClient.fs
@@ -14,8 +14,6 @@ open SharpXMPP.XMPP.Client.Elements
 open Emulsion
 open Emulsion.Xmpp
 
-/// Note: all the subscription methods should be free-threaded, and should expect the lifetime to be terminated in a
-/// free-threaded way (i.e. lifetime termination may come from any thread in the system).
 type IXmppClient =
     abstract member Connect: unit -> Async<unit>
     abstract member JoinMultiUserChat: roomJid: JID -> nickname: string -> password: string option -> unit

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,23 @@ $ dotnet build
 Configure
 ---------
 
-Copy `emulsion.example.json` to `emulsion.json` and set the settings.
+Copy `emulsion.example.json` to `emulsion.json` and set the settings. For some
+settings, there're defaults:
+
+```json
+{
+    "xmpp": {
+        "roomPassword": null,
+        "messageTimeout": "00:05:00",
+        "pingInterval": null,
+        "pingTimeout": "00:00:30"
+    }
+}
+```
+
+All the other settings are required.
+
+Note that `pingInterval` of `null` disables XMPP ping support.
 
 Test
 ----

--- a/emulsion.example.json
+++ b/emulsion.example.json
@@ -5,7 +5,9 @@
         "room": "xxxxx@conference.example.org",
         "roomPassword": "// optional",
         "nickname": "хортолёт",
-        "messageTimeout": "00:05:00"
+        "messageTimeout": "00:05:00",
+        "pingInterval": "00:01:00",
+        "pingTimeout": "00:00:05"
     },
     "telegram": {
         "token": "999999999:aaaaaaaaaaaaaaaaaaaaaaaaa_777777777",


### PR DESCRIPTION
This has been done according to the [XEP-0199: XMPP Ping](https://xmpp.org/extensions/xep-0199.html).

The original idea (that should work, theoretically) is for bot to ping itself in the room (i.e. to ping its room "avatar", `room@conference.server.com/myBotNickname`).

Closes #88 (because it finishes the work on that issue).

**TODO**:
- [x] wait for publication of a new SharpXMPP version