### PR TITLE
Add empty line after the quote

### DIFF
--- a/Emulsion.Tests/Telegram/FunogramTests.fs
+++ b/Emulsion.Tests/Telegram/FunogramTests.fs
@@ -556,7 +556,7 @@ module FlattenMessageTests =
         let originalMessage = authoredTelegramMessage "@originalUser" "Original text"
         let replyMessage = authoredTelegramReplyMessage "@replyingUser" "Reply text" originalMessage.main
         Assert.Equal(
-            Authored { author = "@replyingUser"; text = ">> <@originalUser> Original text\nReply text" },
+            Authored { author = "@replyingUser"; text = ">> <@originalUser> Original text\n\nReply text" },
             flattenMessage replyMessage
         )
 
@@ -565,7 +565,7 @@ module FlattenMessageTests =
         let originalMessage = eventTelegramMessage "@originalUser has entered the chat"
         let replyMessage = authoredTelegramReplyMessage "@replyingUser" "Reply text" originalMessage.main
         Assert.Equal(
-            Authored { author = "@replyingUser"; text = ">> @originalUser has entered the chat\nReply text" },
+            Authored { author = "@replyingUser"; text = ">> @originalUser has entered the chat\n\nReply text" },
             flattenMessage replyMessage
         )
 
@@ -574,7 +574,7 @@ module FlattenMessageTests =
         let originalMessage = authoredTelegramMessage "@originalUser" "1\n2\n3"
         let replyMessage = authoredTelegramReplyMessage "@replyingUser" "Reply text" originalMessage.main
         Assert.Equal(
-            Authored { author = "@replyingUser"; text = ">> <@originalUser> 1\n>> 2\n>> 3\nReply text" },
+            Authored { author = "@replyingUser"; text = ">> <@originalUser> 1\n>> 2\n>> 3\n\nReply text" },
             flattenMessage replyMessage
         )
 
@@ -583,7 +583,7 @@ module FlattenMessageTests =
         let originalMessage = authoredTelegramMessage "@originalUser" "1\n2\n3\n4"
         let replyMessage = authoredTelegramReplyMessage "@replyingUser" "Reply text" originalMessage.main
         Assert.Equal(
-            Authored { author = "@replyingUser"; text = ">> <@originalUser> 1\n>> 2\n>> […]\nReply text" },
+            Authored { author = "@replyingUser"; text = ">> <@originalUser> 1\n>> 2\n>> […]\n\nReply text" },
             flattenMessage replyMessage
         )
 
@@ -593,7 +593,7 @@ module FlattenMessageTests =
         let replyMessage = authoredTelegramReplyMessage "@replyingUser" "Reply text" originalMessage.main
 
         Assert.Equal(
-            Authored { author = "@replyingUser"; text = ">> <@originalUser> 12[…]\nReply text" },
+            Authored { author = "@replyingUser"; text = ">> <@originalUser> 12[…]\n\nReply text" },
             flattenMessageLineLimit 5 replyMessage
         )
 

--- a/Emulsion/Telegram/Funogram.fs
+++ b/Emulsion/Telegram/Funogram.fs
@@ -232,7 +232,7 @@ module MessageConverter =
         | _ -> "[DATA UNRECOGNIZED]"
 
     let private addOriginalMessage quoteSettings originalMessage replyMessageBody =
-        sprintf "%s\n%s" (getQuotedMessage quoteSettings originalMessage) replyMessageBody
+        sprintf "%s\n\n%s" (getQuotedMessage quoteSettings originalMessage) replyMessageBody
 
     let internal flatten (quotedLimits: QuoteSettings) (message: TelegramMessage): Message =
         match message.main with


### PR DESCRIPTION
@noktoborus asked me to put *two* newlines in between the quote and message, presumably so it's easier to tell them
apart: https://codingteam.org.ru/_logs/codingteam%40conference.jabber.ru/2020/12/28.html#14:18:21.504544 I think the bot
should do the same, hence this commit.