### PR TITLE
Use v1 of actions/setup-dotnet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.fsproj') }}
+      - name: Fix "Unable to find package FSharp.Core"
+        run: dotnet clean Emulsion.sln && dotnet nuget locals all --clear
       - name: Build
         run: dotnet build
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.4.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.403'
       - name: NuGet Cache


### PR DESCRIPTION
This avoids the use of deprecated `set-env` call, and makes sure our workflow stays up-to-date with an upstream version.

(This is intended to fix the build failure in #127.)