### PR TITLE
Telegram error processing

### DIFF
--- a/Emulsion.Tests/Telegram/FunogramTests.fs
+++ b/Emulsion.Tests/Telegram/FunogramTests.fs
@@ -193,7 +193,7 @@ module ReadMessageTests =
         let expectedMessage = { createMessage None None with Chat = privateChat }
         Assert.Equal(
             authoredTelegramMessage "[UNKNOWN USER]" "[DATA UNRECOGNIZED]",
-            readMessage (expectedMessage)
+            readMessage expectedMessage
         )
 
     [<Fact>]
@@ -322,7 +322,7 @@ module ReadMessageTests =
         let forwardedMessage = createMessage (Some originalUser) (Some multilineMessage)
         let message = createForwardedMessage forwardingUser forwardedMessage
         let quotedMultilineMessage = "test" + String.init messageLinesLimit (fun _ -> "\n>> test")
-        let telegramMessageText = sprintf ">> <@originalUser> %s" quotedMultilineMessage
+        let telegramMessageText = $">> <@originalUser> {quotedMultilineMessage}"
 
         Assert.Equal(
             authoredTelegramMessage "@forwardingUser" telegramMessageText,
@@ -335,7 +335,7 @@ module ReadMessageTests =
         let longString = String.init (messageLengthLimit + 1) (fun _ -> "A")
         let forwardedMessage = createMessage (Some originalUser) (Some longString)
         let message = createForwardedMessage forwardingUser forwardedMessage
-        let telegramMessageText = sprintf ">> <@originalUser> %s" longString
+        let telegramMessageText = $">> <@originalUser> {longString}"
 
         Assert.Equal(
             authoredTelegramMessage "@forwardingUser" telegramMessageText,
@@ -611,6 +611,6 @@ module PrepareMessageTests =
     [<Fact>]
     let prepareMessageEscapesHtml() =
         Assert.Equal(
-            "<b>user &lt;3</b>\nmymessage &lt;&amp;&gt;",
-            Funogram.prepareHtmlMessage (Authored { author = "user <3"; text = "mymessage <&>" })
+            "<b>user &lt;3</b>\nmy_message &lt;&amp;&gt;",
+            Funogram.prepareHtmlMessage (Authored { author = "user <3"; text = "my_message <&>" })
         )

--- a/Emulsion.sln.DotSettings
+++ b/Emulsion.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Funogram/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Overquoted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Receival/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=workflows/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=XMPP/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Emulsion/Telegram/Client.fs
+++ b/Emulsion/Telegram/Client.fs
@@ -16,4 +16,4 @@ type Client(ctx: ServiceContext, cancellationToken: CancellationToken, settings:
     }
 
     override _.Send message =
-        Funogram.send ctx.Logger settings botConfig message
+        Funogram.send settings botConfig message


### PR DESCRIPTION
Closes #133.

Turns out we weren't processing Telegram server errors properly: we were just logging them instead of throwing them to the message system (so it would know that the message wasn't delivered and start throttling it).