### PR TITLE
MessageSender: process Error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Additional logging for mailbox processor errors
+
 ## [1.7.0] - 2021-06-29
 ### Changed
 - Runtime: upgrade to .NET 5

--- a/Emulsion/MessageSender.fs
+++ b/Emulsion/MessageSender.fs
@@ -87,7 +87,9 @@ let internal receiver (ctx: MessageSenderContext) (inbox: Sender): Async<unit> =
     loop State.initial
 
 let startActivity(ctx: MessageSenderContext, token: CancellationToken): Sender =
-    MailboxProcessor.Start(receiver ctx, token)
+    let processor = MailboxProcessor.Start(receiver ctx, token)
+    processor.Error.Add(fun ex -> ctx.Logger.Error(ex, "Error observed by the message sender mailbox"))
+    processor
 
 let setReadyToAcceptMessages(activity: Sender): bool -> unit = SetReceiveStatus >> activity.Post
 let send(activity: Sender): OutgoingMessage -> unit = QueueMessage >> activity.Post


### PR DESCRIPTION
After reading the [F# Async Guide](https://medium.com/@eulerfx/f-async-guide-eb3c8a2d180a), I've found that we may miss errors in our mailboxes. Yes, our mailbox code is written in a pretty robust way and shouldn't ever trigger the `Error` event, but what if it isn't? Who really knows? We'll start logging these events and will see if that is the case.