### PR TITLE
Solution: get rid of redundant platforms

### DIFF
--- a/Emulsion.sln
+++ b/Emulsion.sln
@@ -43,11 +43,7 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -63,28 +59,12 @@ Global
 		{1B3B65DD-FD58-45FA-B6FF-8532B513A7D9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|x64.Build.0 = Debug|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Debug|x86.Build.0 = Debug|Any CPU
 		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|x64.ActiveCfg = Release|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|x64.Build.0 = Release|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|x86.ActiveCfg = Release|Any CPU
-		{0111F688-1AE2-4B5D-BF46-D60B64078788}.Release|x86.Build.0 = Release|Any CPU
 		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|x64.Build.0 = Debug|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Debug|x86.Build.0 = Debug|Any CPU
 		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|x64.ActiveCfg = Release|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|x64.Build.0 = Release|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|x86.ActiveCfg = Release|Any CPU
-		{A520FD41-A1CB-4062-AFBC-62A8BED12E81}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7D1ADF47-BF1C-4007-BB9B-08C283044467} = {973131E1-E645-4A50-A0D2-1886A1A8F0C6}


### PR DESCRIPTION
No idea why they were here. We only build/test for "Any CPU".