### PR TITLE
Stable sort for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] (2.4.2)
+### Fixed
+- Message archive entries are stored by id in a stable way.
+
 ## [2.4.1] - 2023-07-06
 ### Fixed
 - Restore old content URL on `/content` instead of new `/api/content`

--- a/Emulsion.Web/HistoryController.fs
+++ b/Emulsion.Web/HistoryController.fs
@@ -45,6 +45,12 @@ type HistoryController(context: EmulsionDbContext) =
 
     [<HttpGet("messages")>]
     member this.GetMessages(offset: int, limit: int): Task<IEnumerable<Message>> = task {
-        let! messages = context.ArchiveEntries.Skip(offset).Take(limit).ToListAsync()
+        let! messages =
+            (query {
+                for entry in context.ArchiveEntries do
+                sortBy entry.Id
+                skip offset
+                take limit
+            }).ToListAsync()
         return messages |> Seq.map convertMessage
     }


### PR DESCRIPTION
They already work that way according to [the spec](https://www.sqlite.org/queryplanner.html), though I'd like to make the code more clear.

Also, this will allow us to have stable order if we ever switch the database provider.

I wish it'd be possible to sort by the message datetime, but EFCore doesn't seem to support that for SQLite.