### PR TITLE
LoggingTests: add filter for test category

### DIFF
--- a/Emulsion.Tests/LoggingTests.fs
+++ b/Emulsion.Tests/LoggingTests.fs
@@ -12,7 +12,9 @@ let ``attachToRdLogSystem should proxy the logged messages``(): unit =
     let events = ResizeArray()
     let serilogLogger = {
         new ILogger with
-            override this.Write(logEvent) = lock events (fun() -> events.Add logEvent)
+            override this.Write(logEvent) =
+                if logEvent.Properties[Constants.SourceContextPropertyName].ToString() = "\"LoggingTests\"" then
+                    lock events (fun() -> events.Add logEvent)
     }
     let rdLogger = Log.GetLog "LoggingTests"
     use _ = Logging.attachToRdLogSystem serilogLogger


### PR DESCRIPTION
Otherwise, concurrent tests could log something else and break our assertions.