### PR TITLE
Improve test stability

### DIFF
--- a/Emulsion.TestFramework/Emulsion.TestFramework.fsproj
+++ b/Emulsion.TestFramework/Emulsion.TestFramework.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="WebFileStorage.fs" />
     <Compile Include="FileCacheUtil.fs" />
     <Compile Include="StreamUtils.fs" />
+    <Compile Include="Signals.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Emulsion.TestFramework/Signals.fs
+++ b/Emulsion.TestFramework/Signals.fs
@@ -1,0 +1,15 @@
+﻿module Emulsion.TestFramework.Signals
+
+open System
+open System.Threading.Tasks
+open JetBrains.Collections.Viewable
+open JetBrains.Lifetimes
+
+let WaitWithTimeout (lt: Lifetime) (source: ISource<Unit>) (timeout: TimeSpan) (message: string): Task = task {
+    let delay = Task.Delay timeout
+    let waiter = source.NextValueAsync lt
+    let! _ = Task.WhenAny(waiter, delay)
+    if not waiter.IsCompleted then
+        failwithf $"Timeout of {timeout} when waiting for {message}."
+    do! Task.Yield() // to untangle further actions from the signal task termination
+}

--- a/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
+++ b/Emulsion.Tests/Xmpp/EmulsionXmppTests.fs
@@ -11,7 +11,6 @@ open SharpXMPP.XMPP.Client.Elements
 open Xunit
 open Xunit.Abstractions
 
-open Emulsion
 open Emulsion.Messaging
 open Emulsion.Settings
 open Emulsion.TestFramework
@@ -195,7 +194,7 @@ type SendTests(outputHelper: ITestOutputHelper) =
         task {
             use ld = Lifetime.Define()
             let lt = ld.Lifetime
-            let messageId = lt.CreateTaskCompletionSource()
+            let messageId = lt.CreateTaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
             let messageHandlers = ResizeArray()
             let onMessage msg = messageHandlers |> Seq.iter (fun h -> h msg)
 
@@ -213,7 +212,7 @@ type SendTests(outputHelper: ITestOutputHelper) =
             let! messageId = Async.AwaitTask messageId.Task // the send has been completed
 
             // Wait for 100 ms to check that the receival is not completed yet:
-            Assert.False(receivalTask.Wait(TimeSpan.FromMilliseconds 100.0))
+            Assert.False(receivalTask.Wait(TimeSpan.FromSeconds 10.0))
 
             let deliveryMessage = SharpXmppHelper.message messageId "" ""
             onMessage deliveryMessage

--- a/Emulsion.Tests/Xmpp/XmppClientRoomTests.fs
+++ b/Emulsion.Tests/Xmpp/XmppClientRoomTests.fs
@@ -199,7 +199,7 @@ type XmppClientRoomTests(output: ITestOutputHelper) =
                 let waiter = waitForIqSent lt iqSent
                 let! connection = Async.StartChild <| XmppClient.enterRoom logger client lt roomInfoWithPing
                 do! assertNoPingSent iqMessages
-                lock join !join // ha-ha
+                lock join (fun() -> (!join)())
                 let! _ = connection
                 do! assertPingSent waiter iqMessages
             }


### PR DESCRIPTION
Hopefully should fix #187 and fix #220.

My current hypothesis is that the tests experience timeout problems because of too much happening in parallel on the agents. I have even reproduced one failure locally.

After these improvements, I didn't reproduce any problems so far. We'll see how it'll behave.

Another issue is that our ping locator pattern was to "wait for X ms and then check if we receive all the expected messages". I have updated that to await the message asynchronously: this allows us to extend the waiting timeout without hurting the total test duration in the happy case.