### PR TITLE
CI: publish as a framework-dependent app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,26 @@ jobs:
           name: changelog-section.md
           path: ./changelog-section.md
 
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: NuGet cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.fsproj') }}
+      - name: Publish
+        run: dotnet publish Emulsion --output publish -p:UseAppHost=false
+      - name: Pack
+        shell: pwsh
+        run: Compress-Archive -Path publish -DestinationPath emulsion-${{ steps.version.outputs.version }}.zip
+
+      - name: Upload the pack result
+        uses: actions/upload-artifact@v4
+        with:
+          path: emulsion-${{ steps.version.outputs.version }}.zip
+
       - name: Create a release
         if: startsWith(github.ref, 'refs/tags/v')
         # noinspection SpellCheckingInspection
@@ -42,3 +62,5 @@ jobs:
         with:
           name: Emulsion v${{ steps.version.outputs.version }}
           body_path: ./changelog-section.md
+          files: |
+            emulsion-${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.github/nuget-packages
     steps:
       - name: Read version from Git ref
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Upload the pack result
         uses: actions/upload-artifact@v4
         with:
+          name: emulsion-${{ steps.version.outputs.version }}.zip
           path: emulsion-${{ steps.version.outputs.version }}.zip
 
       - name: Create a release

--- a/.idea/.idea.Emulsion/.idea/dictionaries/fried.xml
+++ b/.idea/.idea.Emulsion/.idea/dictionaries/fried.xml
@@ -1,6 +1,8 @@
 <component name="ProjectDictionaryState">
   <dictionary name="fried">
     <words>
+      <w>andivionian</w>
+      <w>aquana</w>
       <w>codingteam</w>
       <w>fhtagn</w>
       <w>maintainership</w>

--- a/Emulsion/Emulsion.fsproj
+++ b/Emulsion/Emulsion.fsproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Version>2.4.4</Version>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Logging.fs" />

--- a/README.md
+++ b/README.md
@@ -3,6 +3,50 @@ emulsion [![Docker Image][badge.docker]][docker-hub] [![Status Aquana][status-aq
 
 emulsion is a bridge between [Telegram][telegram] and [XMPP][xmpp].
 
+Installation
+------------
+There are two supported Emulsion distributions: as a framework-dependent .NET application, or as a Docker image.
+
+### .NET Application
+To run Emulsion as [a framework-dependent .NET application][docs.dotnet.framework-dependent], you'll need to [install .NET runtime][dotnet.install] version 8.0 or later.
+
+Then, download the required version in the [Releases][releases] section.
+
+After that, configure the application, and start it using the following shell command:
+
+```console
+$ dotnet Emulsion.dll
+```
+
+### Docker
+It is recommended to use Docker to deploy this application. To install the application from Docker, you may use the following Bash script:
+
+```bash
+NAME=emulsion
+EMULSION_VERSION=latest
+CONFIG=/opt/codingteam/emulsion/emulsion.json
+DATA=/opt/codingteam/emulsion/data # optional
+WEB_PORT=5051 # optional
+docker pull codingteam/emulsion:$EMULSION_VERSION
+docker rm -f $NAME
+docker run --name $NAME \
+    -v $CONFIG:/app/emulsion.json:ro \
+    -v $DATA:/data \
+    -p 127.0.0.1:$WEB_PORT:5000 \
+    --restart unless-stopped \
+    -d \
+    codingteam/emulsion:$EMULSION_VERSION
+```
+
+where
+
+- `$NAME` is the container name
+- `$EMULSION_VERSION` is the image version you want to deploy, or `latest` for
+  the latest available one
+- `$CONFIG` is the **absolute** path to the configuration file
+- `$DATA` is the absolute path to the data directory (used by the configuration)
+- `$WEB_PORT` is the port on the host system which will be used to access the content proxy
+
 Build
 -----
 
@@ -104,37 +148,8 @@ Requires [.NET Runtime][dotnet] version 8.0 or newer.
 $ dotnet run --project ./Emulsion [optional-path-to-json-config-file]
 ```
 
-Docker
-------
-It is recommended to use Docker to deploy this project. To install the
-application from Docker, you may use the following Bash script:
-
-```bash
-NAME=emulsion
-EMULSION_VERSION=latest
-CONFIG=/opt/codingteam/emulsion/emulsion.json
-DATA=/opt/codingteam/emulsion/data # optional
-WEB_PORT=5051 # optional
-docker pull codingteam/emulsion:$EMULSION_VERSION
-docker rm -f $NAME
-docker run --name $NAME \
-    -v $CONFIG:/app/emulsion.json:ro \
-    -v $DATA:/data \
-    -p 127.0.0.1:$WEB_PORT:5000 \
-    --restart unless-stopped \
-    -d \
-    codingteam/emulsion:$EMULSION_VERSION
-```
-
-where
-
-- `$NAME` is the container name
-- `$EMULSION_VERSION` is the image version you want to deploy, or `latest` for
-  the latest available one
-- `$CONFIG` is the **absolute** path to the configuration file
-- `$DATA` is the absolute path to the data directory (used by the configuration)
-- `$WEB_PORT` is the port on the host system which will be used to access the content proxy
-
+Docker Publish
+--------------
 To build and push the container to Docker Hub, use the following commands:
 
 ```console
@@ -162,15 +177,17 @@ Developer documentation:
 - [Maintainership][docs.maintainership]
 
 [andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-aquana-
+[badge.docker]: https://img.shields.io/docker/v/codingteam/emulsion?sort=semver
 [docker-hub]: https://hub.docker.com/r/codingteam/emulsion
 [docs.changelog]: ./CHANGELOG.md
 [docs.create-migration]: ./docs/create-migration.md
+[docs.dotnet.framework-dependent]: https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-framework-dependent
 [docs.license]: ./LICENSE.md
 [docs.maintainership]: MAINTAINERSHIP.md
+[dotnet.install]: https://dot.net
 [dotnet]: https://dotnet.microsoft.com/download
 [hashids.net]: https://github.com/ullmark/hashids.net
+[releases]: https://github.com/codingteam/emulsion/releases
+[status-aquana]: https://img.shields.io/badge/status-aquana-yellowgreen.svg
 [telegram]: https://telegram.org/
 [xmpp]: https://xmpp.org/
-
-[badge.docker]: https://img.shields.io/docker/v/codingteam/emulsion?sort=semver
-[status-aquana]: https://img.shields.io/badge/status-aquana-yellowgreen.svg


### PR DESCRIPTION
In addition to Docker, we'll start publishing Emulsion as framework-dependent app (meaning it's possible to run using an external `dotnet` installation).