### PR TITLE
CI: enumerate all project files when calculating caching policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.NUGET_PACKAGES }}
-          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.fsproj') }}
+          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.*proj') }}
       - name: Build
         run: dotnet build
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.NUGET_PACKAGES }}
-          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.fsproj') }}
+          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.*proj') }}
       - name: Publish
         run: dotnet publish Emulsion --output publish -p:UseAppHost=false
       - name: Pack


### PR DESCRIPTION
We have `*.proj` as well as `*.fsproj`.